### PR TITLE
feat: Slack bridge 2-way sync with browser extension

### DIFF
--- a/api/config/default.toml
+++ b/api/config/default.toml
@@ -193,7 +193,6 @@ required_oauth_scopes = [
   "users:read",
 ]
 use_as_oauth_user_scopes = true
-warning_message = "Slack mentions synchronization is only one way from Slack to Universal Inbox. Indeed, using Slack public API, it is not possible mark messages as read or to unsubscribe from a thread."
 
 [integrations.ticktick]
 name = "Tick Tick"

--- a/api/migrations/20260408170000_create_slack_bridge_pending_action.down.sql
+++ b/api/migrations/20260408170000_create_slack_bridge_pending_action.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS slack_bridge_pending_action;

--- a/api/migrations/20260408170000_create_slack_bridge_pending_action.up.sql
+++ b/api/migrations/20260408170000_create_slack_bridge_pending_action.up.sql
@@ -1,0 +1,18 @@
+CREATE TABLE slack_bridge_pending_action (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES "user"(id),
+    notification_id UUID REFERENCES notification(id),
+    action_type TEXT NOT NULL,
+    slack_team_id TEXT NOT NULL,
+    slack_channel_id TEXT NOT NULL,
+    slack_thread_ts TEXT NOT NULL,
+    slack_last_message_ts TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'Pending',
+    failure_message TEXT,
+    retry_count INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    completed_at TIMESTAMP WITH TIME ZONE
+);
+
+CREATE INDEX idx_slack_bridge_pending_action_user_status ON slack_bridge_pending_action (user_id, status);

--- a/api/src/commands/generate.rs
+++ b/api/src/commands/generate.rs
@@ -374,6 +374,7 @@ async fn generate_slack_notifications_and_tasks(
             message_config: SlackMessageConfig {
                 sync_enabled: true,
                 is_2way_sync: false,
+                extension_enabled: true,
             },
         })),
     )

--- a/api/src/commands/mod.rs
+++ b/api/src/commands/mod.rs
@@ -21,8 +21,8 @@ use crate::{
         UniversalInboxError, auth_token::service::AuthenticationTokenService,
         integration_connection::service::IntegrationConnectionService,
         notification::service::NotificationService, oauth2::service::OAuth2Service,
-        task::service::TaskService, third_party::service::ThirdPartyItemService,
-        user::service::UserService,
+        slack_bridge::service::SlackBridgeService, task::service::TaskService,
+        third_party::service::ThirdPartyItemService, user::service::UserService,
     },
     utils::{cache::Cache, jwt::JWTBase64EncodedSigningKeys},
 };
@@ -230,6 +230,7 @@ impl Cli {
         auth_token_service: Arc<RwLock<AuthenticationTokenService>>,
         third_party_item_service: Arc<RwLock<ThirdPartyItemService>>,
         slack_service: Arc<SlackService>,
+        slack_bridge_service: Arc<SlackBridgeService>,
         oauth2_service: Arc<OAuth2Service>,
     ) -> Result<(), UniversalInboxError> {
         match &self.command {
@@ -321,6 +322,7 @@ impl Cli {
                     integration_connection_service.clone(),
                     auth_token_service,
                     third_party_item_service.clone(),
+                    slack_bridge_service,
                     oauth2_service,
                 )
                 .await

--- a/api/src/integrations/oauth2/mod.rs
+++ b/api/src/integrations/oauth2/mod.rs
@@ -77,6 +77,8 @@ impl NangoConnection {
         match self.provider_config_key.0.as_str() {
             "slack" => Some(IntegrationConnectionContext::Slack(SlackContext {
                 team_id: SlackTeamId(self.credentials.raw["team"]["id"].as_str()?.to_string()),
+                extension_credentials: vec![],
+                last_extension_heartbeat_at: None,
             })),
             _ => None,
         }

--- a/api/src/integrations/slack.rs
+++ b/api/src/integrations/slack.rs
@@ -43,6 +43,7 @@ use crate::{
     },
     universal_inbox::{
         UniversalInboxError, integration_connection::service::IntegrationConnectionService,
+        slack_bridge::service::SlackBridgeService,
     },
     utils::cache::build_redis_cache,
 };
@@ -53,20 +54,77 @@ static SLACK_BASE_URL: &str = "https://api.slack.com/api";
 pub struct SlackService {
     slack_base_url: String,
     integration_connection_service: Arc<RwLock<IntegrationConnectionService>>,
+    slack_bridge_service: Arc<SlackBridgeService>,
 }
 
 impl SlackService {
     pub fn new(
         slack_base_url: Option<String>,
         integration_connection_service: Arc<RwLock<IntegrationConnectionService>>,
+        slack_bridge_service: Arc<SlackBridgeService>,
     ) -> Self {
         Self {
             slack_base_url: slack_base_url.unwrap_or_else(|| SLACK_BASE_URL.to_string()),
             integration_connection_service,
+            slack_bridge_service,
         }
     }
 
     pub async fn mock_all(_mock_server: &MockServer) {}
+
+    async fn create_bridge_pending_action_if_enabled(
+        &self,
+        executor: &mut Transaction<'_, Postgres>,
+        source_item: &ThirdPartyItem,
+        user_id: UserId,
+        action_type: universal_inbox::slack_bridge::SlackBridgeActionType,
+    ) -> Result<(), UniversalInboxError> {
+        let ThirdPartyItemData::SlackThread(slack_thread) = &source_item.data else {
+            return Ok(()); // Not a SlackThread — no-op
+        };
+
+        // Check if extension bridge is enabled for this user
+        let integration_connection_service = self.integration_connection_service.read().await;
+        let (_, integration_connection) = match integration_connection_service
+            .find_access_token(executor, IntegrationProviderKind::Slack, user_id)
+            .await?
+        {
+            Some(result) => result,
+            None => return Ok(()), // No Slack connection
+        };
+
+        let extension_enabled = match &integration_connection.provider {
+            universal_inbox::integration_connection::provider::IntegrationProvider::Slack {
+                config,
+                ..
+            } => config.message_config.extension_enabled,
+            _ => false,
+        };
+
+        if !extension_enabled {
+            return Ok(());
+        }
+
+        let team_id = slack_thread.team.id.clone();
+        let channel_id = slack_thread.channel.id.clone();
+        let thread_ts = slack_thread.messages.first().origin.ts.clone();
+        let last_message_ts = slack_thread.messages.last().origin.ts.clone();
+
+        self.slack_bridge_service
+            .create_pending_action(
+                executor,
+                user_id,
+                None,
+                action_type,
+                team_id,
+                channel_id,
+                thread_ts,
+                last_message_ts,
+            )
+            .await?;
+
+        Ok(())
+    }
 
     pub fn build_slack_client(
         &self,
@@ -1235,21 +1293,25 @@ impl ThirdPartyNotificationSourceService<SlackThread> for SlackService {
         skip_all,
         fields(
             third_party_item_id = source_item.id.to_string(),
-            user.id = _user_id.to_string()
+            user.id = user_id.to_string()
         ),
         err
     )]
     async fn delete_notification_from_source(
         &self,
-        _executor: &mut Transaction<'_, Postgres>,
+        executor: &mut Transaction<'_, Postgres>,
         source_item: &ThirdPartyItem,
-        _user_id: UserId,
+        user_id: UserId,
     ) -> Result<(), UniversalInboxError> {
-        // There is no way to mark a Slack thread as read with public API
-        // For message in the channel, the read mark can be updated but will mark as
-        // read all messages before the given timestamp.
-        // This might not be what we want for now, perhaps later with an option
-        Ok(())
+        // Slack's public API cannot mark threads as read.
+        // When extension bridge is enabled, queue a pending action for the extension to execute.
+        self.create_bridge_pending_action_if_enabled(
+            executor,
+            source_item,
+            user_id,
+            universal_inbox::slack_bridge::SlackBridgeActionType::MarkAsRead,
+        )
+        .await
     }
 
     #[allow(clippy::blocks_in_conditions)]
@@ -1258,18 +1320,25 @@ impl ThirdPartyNotificationSourceService<SlackThread> for SlackService {
         skip_all,
         fields(
             third_party_item_id = source_item.id.to_string(),
-            user.id = _user_id.to_string()
+            user.id = user_id.to_string()
         ),
         err
     )]
     async fn unsubscribe_notification_from_source(
         &self,
-        _executor: &mut Transaction<'_, Postgres>,
+        executor: &mut Transaction<'_, Postgres>,
         source_item: &ThirdPartyItem,
-        _user_id: UserId,
+        user_id: UserId,
     ) -> Result<(), UniversalInboxError> {
-        // The is no way to unsubscribe from a Slack thread with the public API
-        Ok(())
+        // Slack's public API cannot unsubscribe from threads.
+        // When extension bridge is enabled, queue a pending action for the extension to execute.
+        self.create_bridge_pending_action_if_enabled(
+            executor,
+            source_item,
+            user_id,
+            universal_inbox::slack_bridge::SlackBridgeActionType::Unsubscribe,
+        )
+        .await
     }
 
     async fn snooze_notification_from_source(

--- a/api/src/jobs/slack/slack_message.rs
+++ b/api/src/jobs/slack/slack_message.rs
@@ -55,6 +55,8 @@ pub async fn handle_slack_message_push_event(
                     executor,
                     IntegrationConnectionContext::Slack(SlackContext {
                         team_id: team_id.clone(),
+                        extension_credentials: vec![],
+                        last_extension_heartbeat_at: None,
                     }),
                 )
                 .await?
@@ -166,6 +168,7 @@ async fn handle_slack_message_push_event_if_enabled(
             SlackMessageConfig {
                 sync_enabled: true,
                 is_2way_sync,
+                ..
             },
         ..
     } = slack_config

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -72,8 +72,8 @@ use crate::{
         UniversalInboxError, auth_token::service::AuthenticationTokenService,
         integration_connection::service::IntegrationConnectionService,
         notification::service::NotificationService, oauth2::service::OAuth2Service,
-        task::service::TaskService, third_party::service::ThirdPartyItemService,
-        user::service::UserService,
+        slack_bridge::service::SlackBridgeService, task::service::TaskService,
+        third_party::service::ThirdPartyItemService, user::service::UserService,
     },
     utils::{
         crypto::TokenEncryptionKey,
@@ -106,6 +106,7 @@ pub async fn run_server(
     integration_connection_service: Arc<RwLock<IntegrationConnectionService>>,
     auth_token_service: Arc<RwLock<AuthenticationTokenService>>,
     third_party_item_service: Arc<RwLock<ThirdPartyItemService>>,
+    slack_bridge_service: Arc<SlackBridgeService>,
     oauth2_service: Arc<OAuth2Service>,
 ) -> Result<Server, UniversalInboxError> {
     let api_path = settings.application.api_path.clone();
@@ -204,6 +205,7 @@ pub async fn run_server(
             .service(routes::user::scope())
             .service(routes::webhook::scope())
             .service(routes::third_party::scope())
+            .service(routes::slack_bridge::scope())
             .service(mcp::scope(
                 mcp_http_service.clone(),
                 mcp_rate_limiter.clone(),
@@ -215,6 +217,7 @@ pub async fn run_server(
             .app_data(web::Data::new(user_service.clone()))
             .app_data(web::Data::new(auth_token_service.clone()))
             .app_data(web::Data::new(third_party_item_service.clone()))
+            .app_data(web::Data::new(slack_bridge_service.clone()))
             .app_data(web::Data::new(oauth2_service.clone()));
 
         let api_path_for_cors = api_path.clone();
@@ -467,6 +470,7 @@ pub async fn build_services(
     Arc<RwLock<AuthenticationTokenService>>,
     Arc<RwLock<ThirdPartyItemService>>,
     Arc<SlackService>,
+    Arc<SlackBridgeService>,
     Arc<OAuth2Service>,
 ) {
     let repository = Arc::new(Repository::new(pool.clone()));
@@ -607,9 +611,11 @@ pub async fn build_services(
         .expect("Failed to create new GoogleDriveService"),
     ));
 
+    let slack_bridge_service = Arc::new(SlackBridgeService::new(repository.clone()));
     let slack_service = Arc::new(SlackService::new(
         slack_base_url,
         integration_connection_service.clone(),
+        slack_bridge_service.clone(),
     ));
     let api_service = Arc::new(APIService::new());
 
@@ -702,6 +708,7 @@ pub async fn build_services(
         auth_token_service,
         third_party_item_service,
         slack_service,
+        slack_bridge_service,
         oauth2_service,
     )
 }

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -156,6 +156,7 @@ async fn main() -> std::io::Result<()> {
         auth_token_service,
         third_party_item_service,
         slack_service,
+        slack_bridge_service,
         oauth2_service,
     ) = build_services(
         pool,
@@ -184,6 +185,7 @@ async fn main() -> std::io::Result<()> {
             auth_token_service,
             third_party_item_service,
             slack_service,
+            slack_bridge_service,
             oauth2_service,
         )
         .await

--- a/api/src/repository/mod.rs
+++ b/api/src/repository/mod.rs
@@ -10,6 +10,7 @@ pub mod integration_connection;
 pub mod notification;
 pub mod oauth2;
 pub mod oauth_credential;
+pub mod slack_bridge;
 pub mod task;
 pub mod third_party;
 pub mod user;

--- a/api/src/repository/slack_bridge.rs
+++ b/api/src/repository/slack_bridge.rs
@@ -1,0 +1,285 @@
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use sqlx::{FromRow, Postgres, Row, Transaction};
+use uuid::Uuid;
+
+use universal_inbox::{
+    slack_bridge::{
+        SlackBridgeActionStatus, SlackBridgeActionType, SlackBridgePendingAction,
+        SlackBridgePendingActionId,
+    },
+    user::UserId,
+};
+
+use crate::{repository::Repository, universal_inbox::UniversalInboxError};
+
+const MAX_RETRIES: i32 = 5;
+const BACKOFF_BASE_DELAY_SECONDS: f64 = 30.0;
+const BACKOFF_MAX_DELAY_SECONDS: f64 = 600.0;
+
+#[derive(Debug, FromRow)]
+struct SlackBridgePendingActionRow {
+    id: Uuid,
+    user_id: Uuid,
+    notification_id: Option<Uuid>,
+    action_type: String,
+    slack_team_id: String,
+    slack_channel_id: String,
+    slack_thread_ts: String,
+    slack_last_message_ts: String,
+    status: String,
+    failure_message: Option<String>,
+    retry_count: i32,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+    completed_at: Option<DateTime<Utc>>,
+}
+
+impl TryFrom<SlackBridgePendingActionRow> for SlackBridgePendingAction {
+    type Error = UniversalInboxError;
+
+    fn try_from(row: SlackBridgePendingActionRow) -> Result<Self, Self::Error> {
+        Ok(SlackBridgePendingAction {
+            id: row.id.into(),
+            user_id: row.user_id.into(),
+            notification_id: row.notification_id.map(|id| id.into()),
+            action_type: match row.action_type.as_str() {
+                "MarkAsRead" => SlackBridgeActionType::MarkAsRead,
+                "Unsubscribe" => SlackBridgeActionType::Unsubscribe,
+                other => {
+                    return Err(UniversalInboxError::Unexpected(anyhow::anyhow!(
+                        "Unknown SlackBridgeActionType: {other}"
+                    )));
+                }
+            },
+            slack_team_id: row.slack_team_id.into(),
+            slack_channel_id: row.slack_channel_id.into(),
+            slack_thread_ts: row.slack_thread_ts.into(),
+            slack_last_message_ts: row.slack_last_message_ts.into(),
+            status: match row.status.as_str() {
+                "Pending" => SlackBridgeActionStatus::Pending,
+                "Completed" => SlackBridgeActionStatus::Completed,
+                "Failed" => SlackBridgeActionStatus::Failed,
+                "PermanentlyFailed" => SlackBridgeActionStatus::PermanentlyFailed,
+                other => {
+                    return Err(UniversalInboxError::Unexpected(anyhow::anyhow!(
+                        "Unknown SlackBridgeActionStatus: {other}"
+                    )));
+                }
+            },
+            failure_message: row.failure_message,
+            retry_count: row.retry_count,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+            completed_at: row.completed_at,
+        })
+    }
+}
+
+#[async_trait]
+pub trait SlackBridgeRepository {
+    async fn create_pending_action(
+        &self,
+        executor: &mut Transaction<'_, Postgres>,
+        action: &SlackBridgePendingAction,
+    ) -> Result<SlackBridgePendingAction, UniversalInboxError>;
+
+    async fn get_actionable_actions(
+        &self,
+        executor: &mut Transaction<'_, Postgres>,
+        user_id: UserId,
+    ) -> Result<Vec<SlackBridgePendingAction>, UniversalInboxError>;
+
+    async fn mark_action_completed(
+        &self,
+        executor: &mut Transaction<'_, Postgres>,
+        action_id: SlackBridgePendingActionId,
+        user_id: UserId,
+    ) -> Result<Option<SlackBridgePendingAction>, UniversalInboxError>;
+
+    async fn mark_action_failed(
+        &self,
+        executor: &mut Transaction<'_, Postgres>,
+        action_id: SlackBridgePendingActionId,
+        user_id: UserId,
+        error: &str,
+    ) -> Result<Option<SlackBridgePendingAction>, UniversalInboxError>;
+
+    async fn get_bridge_status(
+        &self,
+        executor: &mut Transaction<'_, Postgres>,
+        user_id: UserId,
+    ) -> Result<(i64, i64, Option<DateTime<Utc>>), UniversalInboxError>;
+}
+
+#[async_trait]
+impl SlackBridgeRepository for Repository {
+    #[tracing::instrument(level = "debug", skip_all, fields(action_id = action.id.to_string()), err)]
+    async fn create_pending_action(
+        &self,
+        executor: &mut Transaction<'_, Postgres>,
+        action: &SlackBridgePendingAction,
+    ) -> Result<SlackBridgePendingAction, UniversalInboxError> {
+        let row: SlackBridgePendingActionRow = sqlx::query_as(
+            r#"
+                INSERT INTO slack_bridge_pending_action
+                    (id, user_id, notification_id, action_type, slack_team_id,
+                     slack_channel_id, slack_thread_ts, slack_last_message_ts,
+                     status, created_at, updated_at)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+                RETURNING *
+            "#,
+        )
+        .bind(action.id.0)
+        .bind(action.user_id.0)
+        .bind(action.notification_id.map(|id| id.0))
+        .bind(action.action_type.to_string())
+        .bind(action.slack_team_id.to_string())
+        .bind(action.slack_channel_id.to_string())
+        .bind(action.slack_thread_ts.to_string())
+        .bind(action.slack_last_message_ts.to_string())
+        .bind(action.status.to_string())
+        .bind(action.created_at)
+        .bind(action.updated_at)
+        .fetch_one(&mut **executor)
+        .await
+        .map_err(|err| UniversalInboxError::DatabaseError {
+            source: err,
+            message: "Failed to create slack bridge pending action".to_string(),
+        })?;
+
+        row.try_into()
+    }
+
+    #[tracing::instrument(level = "debug", skip_all, fields(user_id = user_id.to_string()), err)]
+    async fn get_actionable_actions(
+        &self,
+        executor: &mut Transaction<'_, Postgres>,
+        user_id: UserId,
+    ) -> Result<Vec<SlackBridgePendingAction>, UniversalInboxError> {
+        let rows: Vec<SlackBridgePendingActionRow> = sqlx::query_as(
+            r#"
+                SELECT *
+                FROM slack_bridge_pending_action
+                WHERE user_id = $1
+                  AND (
+                    (status = 'Pending' AND retry_count = 0)
+                    OR (status = 'Failed' AND updated_at + make_interval(secs =>
+                        LEAST(
+                            $2 * POWER(2, GREATEST(retry_count - 1, 0)),
+                            $3
+                        )
+                    ) < NOW())
+                  )
+                ORDER BY created_at ASC
+            "#,
+        )
+        .bind(user_id.0)
+        .bind(BACKOFF_BASE_DELAY_SECONDS)
+        .bind(BACKOFF_MAX_DELAY_SECONDS)
+        .fetch_all(&mut **executor)
+        .await
+        .map_err(|err| UniversalInboxError::DatabaseError {
+            source: err,
+            message: "Failed to fetch pending slack bridge actions".to_string(),
+        })?;
+
+        rows.into_iter().map(|row| row.try_into()).collect()
+    }
+
+    #[tracing::instrument(level = "debug", skip_all, fields(action_id = action_id.to_string(), user_id = user_id.to_string()), err)]
+    async fn mark_action_completed(
+        &self,
+        executor: &mut Transaction<'_, Postgres>,
+        action_id: SlackBridgePendingActionId,
+        user_id: UserId,
+    ) -> Result<Option<SlackBridgePendingAction>, UniversalInboxError> {
+        let row: Option<SlackBridgePendingActionRow> = sqlx::query_as(
+            r#"
+                UPDATE slack_bridge_pending_action
+                SET status = 'Completed',
+                    completed_at = NOW(),
+                    updated_at = NOW()
+                WHERE id = $1 AND user_id = $2
+                RETURNING *
+            "#,
+        )
+        .bind(action_id.0)
+        .bind(user_id.0)
+        .fetch_optional(&mut **executor)
+        .await
+        .map_err(|err| UniversalInboxError::DatabaseError {
+            source: err,
+            message: "Failed to mark slack bridge action as completed".to_string(),
+        })?;
+
+        row.map(|r| r.try_into()).transpose()
+    }
+
+    #[tracing::instrument(level = "debug", skip_all, fields(action_id = action_id.to_string(), user_id = user_id.to_string()), err)]
+    async fn mark_action_failed(
+        &self,
+        executor: &mut Transaction<'_, Postgres>,
+        action_id: SlackBridgePendingActionId,
+        user_id: UserId,
+        error: &str,
+    ) -> Result<Option<SlackBridgePendingAction>, UniversalInboxError> {
+        let row: Option<SlackBridgePendingActionRow> = sqlx::query_as(
+            r#"
+                UPDATE slack_bridge_pending_action
+                SET status = CASE
+                        WHEN retry_count + 1 >= $2 THEN 'PermanentlyFailed'
+                        ELSE 'Failed'
+                    END,
+                    failure_message = $3,
+                    retry_count = retry_count + 1,
+                    updated_at = NOW()
+                WHERE id = $1 AND user_id = $4
+                RETURNING *
+            "#,
+        )
+        .bind(action_id.0)
+        .bind(MAX_RETRIES)
+        .bind(error)
+        .bind(user_id.0)
+        .fetch_optional(&mut **executor)
+        .await
+        .map_err(|err| UniversalInboxError::DatabaseError {
+            source: err,
+            message: "Failed to mark slack bridge action as failed".to_string(),
+        })?;
+
+        row.map(|r| r.try_into()).transpose()
+    }
+
+    #[tracing::instrument(level = "debug", skip_all, fields(user_id = user_id.to_string()), err)]
+    async fn get_bridge_status(
+        &self,
+        executor: &mut Transaction<'_, Postgres>,
+        user_id: UserId,
+    ) -> Result<(i64, i64, Option<DateTime<Utc>>), UniversalInboxError> {
+        let row = sqlx::query(
+            r#"
+                SELECT
+                    COALESCE(SUM(CASE WHEN status = 'Pending' THEN 1 ELSE 0 END), 0) as pending_count,
+                    COALESCE(SUM(CASE WHEN status = 'Failed' THEN 1 ELSE 0 END), 0) as failed_count,
+                    MAX(CASE WHEN status = 'Completed' THEN completed_at END) as last_completed_at
+                FROM slack_bridge_pending_action
+                WHERE user_id = $1
+            "#,
+        )
+        .bind(user_id.0)
+        .fetch_one(&mut **executor)
+        .await
+        .map_err(|err| UniversalInboxError::DatabaseError {
+            source: err,
+            message: "Failed to get slack bridge status".to_string(),
+        })?;
+
+        let pending_count: i64 = row.get("pending_count");
+        let failed_count: i64 = row.get("failed_count");
+        let last_completed_at: Option<DateTime<Utc>> = row.get("last_completed_at");
+
+        Ok((pending_count, failed_count, last_completed_at))
+    }
+}

--- a/api/src/routes/mod.rs
+++ b/api/src/routes/mod.rs
@@ -5,6 +5,7 @@ pub mod integration_connection;
 pub mod notification;
 pub mod oauth;
 pub mod oauth2;
+pub mod slack_bridge;
 pub mod task;
 pub mod third_party;
 pub mod user;

--- a/api/src/routes/slack_bridge.rs
+++ b/api/src/routes/slack_bridge.rs
@@ -1,0 +1,149 @@
+use std::sync::Arc;
+
+use actix_jwt_authc::Authenticated;
+use actix_web::{HttpResponse, Scope, web};
+use anyhow::Context;
+use serde::Deserialize;
+
+use universal_inbox::{
+    integration_connection::integrations::slack::SlackExtensionCredential,
+    slack_bridge::SlackBridgePendingActionId, user::UserId,
+};
+
+use crate::universal_inbox::{UniversalInboxError, slack_bridge::service::SlackBridgeService};
+
+use super::super::utils::jwt::Claims;
+
+pub fn scope() -> Scope {
+    web::scope("/slack-bridge")
+        .route("/pending-actions", web::post().to(get_pending_actions))
+        .route(
+            "/actions/{action_id}/complete",
+            web::post().to(complete_action),
+        )
+        .route("/actions/{action_id}/fail", web::post().to(fail_action))
+        .route("/status", web::get().to(get_bridge_status))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PendingActionsRequest {
+    pub credentials: Vec<SlackExtensionCredential>,
+}
+
+pub async fn get_pending_actions(
+    body: web::Json<PendingActionsRequest>,
+    slack_bridge_service: web::Data<Arc<SlackBridgeService>>,
+    authenticated: Authenticated<Claims>,
+) -> Result<HttpResponse, UniversalInboxError> {
+    let user_id = authenticated
+        .claims
+        .sub
+        .parse::<UserId>()
+        .context("Wrong user ID format")?;
+
+    let mut transaction = slack_bridge_service.begin().await?;
+
+    let actions = slack_bridge_service
+        .get_actionable_actions_for_extension(
+            &mut transaction,
+            user_id,
+            body.into_inner().credentials,
+        )
+        .await?;
+
+    transaction
+        .commit()
+        .await
+        .context("Failed to commit transaction")?;
+
+    Ok(HttpResponse::Ok()
+        .content_type("application/json")
+        .body(serde_json::to_string(&actions).context("Failed to serialize response")?))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ActionPath {
+    action_id: SlackBridgePendingActionId,
+}
+
+pub async fn complete_action(
+    path: web::Path<ActionPath>,
+    slack_bridge_service: web::Data<Arc<SlackBridgeService>>,
+    authenticated: Authenticated<Claims>,
+) -> Result<HttpResponse, UniversalInboxError> {
+    let user_id = authenticated
+        .claims
+        .sub
+        .parse::<UserId>()
+        .context("Wrong user ID format")?;
+
+    let mut transaction = slack_bridge_service.begin().await?;
+
+    slack_bridge_service
+        .complete_action(&mut transaction, path.action_id, user_id)
+        .await?;
+
+    transaction
+        .commit()
+        .await
+        .context("Failed to commit transaction")?;
+
+    Ok(HttpResponse::Ok().finish())
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FailActionBody {
+    error: String,
+}
+
+pub async fn fail_action(
+    path: web::Path<ActionPath>,
+    body: web::Json<FailActionBody>,
+    slack_bridge_service: web::Data<Arc<SlackBridgeService>>,
+    authenticated: Authenticated<Claims>,
+) -> Result<HttpResponse, UniversalInboxError> {
+    let user_id = authenticated
+        .claims
+        .sub
+        .parse::<UserId>()
+        .context("Wrong user ID format")?;
+
+    let mut transaction = slack_bridge_service.begin().await?;
+
+    slack_bridge_service
+        .fail_action(&mut transaction, path.action_id, user_id, &body.error)
+        .await?;
+
+    transaction
+        .commit()
+        .await
+        .context("Failed to commit transaction")?;
+
+    Ok(HttpResponse::Ok().finish())
+}
+
+pub async fn get_bridge_status(
+    slack_bridge_service: web::Data<Arc<SlackBridgeService>>,
+    authenticated: Authenticated<Claims>,
+) -> Result<HttpResponse, UniversalInboxError> {
+    let user_id = authenticated
+        .claims
+        .sub
+        .parse::<UserId>()
+        .context("Wrong user ID format")?;
+
+    let mut transaction = slack_bridge_service.begin().await?;
+
+    let status = slack_bridge_service
+        .get_bridge_status(&mut transaction, user_id)
+        .await?;
+
+    transaction
+        .commit()
+        .await
+        .context("Failed to commit transaction")?;
+
+    Ok(HttpResponse::Ok()
+        .content_type("application/json")
+        .body(serde_json::to_string(&status).context("Failed to serialize response")?))
+}

--- a/api/src/universal_inbox/mod.rs
+++ b/api/src/universal_inbox/mod.rs
@@ -8,6 +8,7 @@ pub mod auth_token;
 pub mod integration_connection;
 pub mod notification;
 pub mod oauth2;
+pub mod slack_bridge;
 pub mod task;
 pub mod third_party;
 pub mod user;

--- a/api/src/universal_inbox/slack_bridge/mod.rs
+++ b/api/src/universal_inbox/slack_bridge/mod.rs
@@ -1,0 +1,1 @@
+pub mod service;

--- a/api/src/universal_inbox/slack_bridge/service.rs
+++ b/api/src/universal_inbox/slack_bridge/service.rs
@@ -1,0 +1,242 @@
+use std::sync::Arc;
+
+use chrono::{TimeDelta, Utc};
+use slack_morphism::prelude::*;
+use sqlx::{Postgres, Transaction};
+use uuid::Uuid;
+
+use universal_inbox::{
+    integration_connection::{
+        integrations::slack::{SlackContext, SlackExtensionCredential},
+        provider::{IntegrationConnectionContext, IntegrationProviderKind},
+    },
+    notification::NotificationId,
+    slack_bridge::{
+        SlackBridgeActionStatus, SlackBridgeActionType, SlackBridgePendingAction,
+        SlackBridgePendingActionId, SlackBridgeStatus,
+    },
+    user::UserId,
+};
+
+use universal_inbox::integration_connection::IntegrationConnectionStatus;
+
+use crate::{
+    repository::{
+        Repository, integration_connection::IntegrationConnectionRepository,
+        slack_bridge::SlackBridgeRepository,
+    },
+    universal_inbox::UniversalInboxError,
+};
+
+const EXTENSION_HEARTBEAT_TIMEOUT_SECONDS: i64 = 120;
+
+pub struct SlackBridgeService {
+    repository: Arc<Repository>,
+}
+
+impl SlackBridgeService {
+    pub fn new(repository: Arc<Repository>) -> Self {
+        Self { repository }
+    }
+
+    pub async fn begin(&self) -> Result<Transaction<'_, Postgres>, UniversalInboxError> {
+        self.repository.begin().await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    #[tracing::instrument(
+        level = "debug",
+        skip_all,
+        fields(
+            user_id = %user_id,
+            action_type = %action_type,
+        ),
+        err
+    )]
+    pub async fn create_pending_action(
+        &self,
+        executor: &mut Transaction<'_, Postgres>,
+        user_id: UserId,
+        notification_id: Option<NotificationId>,
+        action_type: SlackBridgeActionType,
+        slack_team_id: SlackTeamId,
+        slack_channel_id: SlackChannelId,
+        slack_thread_ts: SlackTs,
+        slack_last_message_ts: SlackTs,
+    ) -> Result<SlackBridgePendingAction, UniversalInboxError> {
+        let action = SlackBridgePendingAction {
+            id: Uuid::new_v4().into(),
+            user_id,
+            notification_id,
+            action_type,
+            slack_team_id,
+            slack_channel_id,
+            slack_thread_ts,
+            slack_last_message_ts,
+            status: SlackBridgeActionStatus::Pending,
+            failure_message: None,
+            retry_count: 0,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            completed_at: None,
+        };
+
+        self.repository
+            .create_pending_action(executor, &action)
+            .await
+    }
+
+    #[tracing::instrument(
+        level = "debug",
+        skip_all,
+        fields(user_id = %user_id),
+        err
+    )]
+    pub async fn get_actionable_actions_for_extension(
+        &self,
+        executor: &mut Transaction<'_, Postgres>,
+        user_id: UserId,
+        credentials: Vec<SlackExtensionCredential>,
+    ) -> Result<Vec<SlackBridgePendingAction>, UniversalInboxError> {
+        // Update heartbeat and credentials on the Slack integration connection
+        let integration_connection = self
+            .repository
+            .get_integration_connection_per_provider(
+                executor,
+                user_id,
+                IntegrationProviderKind::Slack,
+                None,
+                Some(IntegrationConnectionStatus::Validated),
+            )
+            .await?;
+
+        if let Some(integration_connection) = integration_connection
+            && let universal_inbox::integration_connection::provider::IntegrationProvider::Slack {
+                context: Some(context),
+                ..
+            } = &integration_connection.provider
+        {
+            let updated_context = IntegrationConnectionContext::Slack(SlackContext {
+                team_id: context.team_id.clone(),
+                extension_credentials: credentials,
+                last_extension_heartbeat_at: Some(Utc::now()),
+            });
+
+            self.repository
+                .update_integration_connection_context(
+                    executor,
+                    integration_connection.id,
+                    Some(updated_context),
+                )
+                .await?;
+        }
+
+        self.repository
+            .get_actionable_actions(executor, user_id)
+            .await
+    }
+
+    #[tracing::instrument(
+        level = "debug",
+        skip_all,
+        fields(action_id = %action_id),
+        err
+    )]
+    pub async fn complete_action(
+        &self,
+        executor: &mut Transaction<'_, Postgres>,
+        action_id: SlackBridgePendingActionId,
+        user_id: UserId,
+    ) -> Result<Option<SlackBridgePendingAction>, UniversalInboxError> {
+        self.repository
+            .mark_action_completed(executor, action_id, user_id)
+            .await
+    }
+
+    #[tracing::instrument(
+        level = "debug",
+        skip_all,
+        fields(action_id = %action_id),
+        err
+    )]
+    pub async fn fail_action(
+        &self,
+        executor: &mut Transaction<'_, Postgres>,
+        action_id: SlackBridgePendingActionId,
+        user_id: UserId,
+        error: &str,
+    ) -> Result<Option<SlackBridgePendingAction>, UniversalInboxError> {
+        self.repository
+            .mark_action_failed(executor, action_id, user_id, error)
+            .await
+    }
+
+    #[tracing::instrument(
+        level = "debug",
+        skip_all,
+        fields(user_id = %user_id),
+        err
+    )]
+    pub async fn get_bridge_status(
+        &self,
+        executor: &mut Transaction<'_, Postgres>,
+        user_id: UserId,
+    ) -> Result<SlackBridgeStatus, UniversalInboxError> {
+        let integration_connection = self
+            .repository
+            .get_integration_connection_per_provider(
+                executor,
+                user_id,
+                IntegrationProviderKind::Slack,
+                None,
+                Some(IntegrationConnectionStatus::Validated),
+            )
+            .await?;
+
+        let (extension_connected, team_id_match, user_id_match) =
+            if let Some(ref integration_connection) = integration_connection {
+                match &integration_connection.provider {
+                    universal_inbox::integration_connection::provider::IntegrationProvider::Slack {
+                        context: Some(context),
+                        ..
+                    } => {
+                        let connected = context
+                            .last_extension_heartbeat_at
+                            .map(|heartbeat| {
+                                Utc::now() - heartbeat
+                                    < TimeDelta::seconds(EXTENSION_HEARTBEAT_TIMEOUT_SECONDS)
+                            })
+                            .unwrap_or(false);
+
+                        let matching_credential = context
+                            .extension_credentials
+                            .iter()
+                            .find(|c| c.team_id == context.team_id);
+
+                        let team_match = matching_credential.is_some();
+
+                        let user_match = matching_credential
+                            .zip(integration_connection.provider_user_id.as_ref())
+                            .is_some_and(|(cred, provider_uid)| cred.user_id == *provider_uid);
+
+                        (connected, team_match, user_match)
+                    }
+                    _ => (false, false, false),
+                }
+            } else {
+                (false, false, false)
+            };
+
+        let (pending_actions_count, failed_actions_count, last_completed_at) =
+            self.repository.get_bridge_status(executor, user_id).await?;
+
+        Ok(SlackBridgeStatus {
+            extension_connected,
+            team_id_match,
+            user_id_match,
+            pending_actions_count,
+            failed_actions_count,
+            last_completed_at,
+        })
+    }
+}

--- a/api/tests/api/test_slack_webhook_message.rs
+++ b/api/tests/api/test_slack_webhook_message.rs
@@ -465,6 +465,8 @@ mod job {
             None,
             Some(IntegrationConnectionContext::Slack(SlackContext {
                 team_id: SlackTeamId("T01".to_string()),
+                extension_credentials: vec![],
+                last_extension_heartbeat_at: None,
             })),
         )
         .await;
@@ -485,6 +487,8 @@ mod job {
             None,
             Some(IntegrationConnectionContext::Slack(SlackContext {
                 team_id: SlackTeamId("T01".to_string()),
+                extension_credentials: vec![],
+                last_extension_heartbeat_at: None,
             })),
         )
         .await;
@@ -668,6 +672,8 @@ mod job {
             None,
             Some(IntegrationConnectionContext::Slack(SlackContext {
                 team_id: SlackTeamId("T01".to_string()),
+                extension_credentials: vec![],
+                last_extension_heartbeat_at: None,
             })),
         )
         .await;
@@ -856,6 +862,8 @@ mod job {
             None,
             Some(IntegrationConnectionContext::Slack(SlackContext {
                 team_id: SlackTeamId("T01".to_string()),
+                extension_credentials: vec![],
+                last_extension_heartbeat_at: None,
             })),
         )
         .await;

--- a/api/tests/common/mod.rs
+++ b/api/tests/common/mod.rs
@@ -154,6 +154,8 @@ pub struct TestServices {
     pub integration_connection_service: Arc<RwLock<IntegrationConnectionService>>,
     pub third_party_item_service: Arc<RwLock<ThirdPartyItemService>>,
     pub slack_service: Arc<SlackService>,
+    pub slack_bridge_service:
+        Arc<universal_inbox_api::universal_inbox::slack_bridge::service::SlackBridgeService>,
     pub oauth2_service: Arc<OAuth2Service>,
 }
 
@@ -182,6 +184,7 @@ pub async fn build_test_services(
         auth_token_service,
         third_party_item_service,
         slack_service,
+        slack_bridge_service,
         oauth2_service,
     ) = universal_inbox_api::build_services(
         pool,
@@ -207,6 +210,7 @@ pub async fn build_test_services(
         integration_connection_service,
         third_party_item_service,
         slack_service,
+        slack_bridge_service,
         oauth2_service,
     };
 
@@ -234,6 +238,7 @@ pub async fn spawn_test_server(
         services.integration_connection_service.clone(),
         auth_token_service,
         services.third_party_item_service.clone(),
+        services.slack_bridge_service.clone(),
         services.oauth2_service.clone(),
     )
     .await

--- a/devbox.d/caddy/Caddyfile
+++ b/devbox.d/caddy/Caddyfile
@@ -6,12 +6,12 @@
 	grace_period 2s
 }
 
-https://dev.universal-inbox.com {
+http://dev.universal-inbox.com {
 	log
 	reverse_proxy :{env.API_PORT}
 }
 
-https://oauth-dev.universal-inbox.com {
+http://oauth-dev.universal-inbox.com {
 	log
 	reverse_proxy :{env.NANGO_PORT}
 }

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -16,6 +16,7 @@
   - [Google Mail](config/setup/gmail.md)
   - [Linear](config/setup/linear.md)
   - [Slack](config/setup/slack.md)
+  - [Browser Extension](config/setup/browser-extension.md)
   - [Todoist](config/setup/todoist.md)
   - [Google Calendar](config/setup/gcal.md)
   - [Google Drive](config/setup/gdrive.md)

--- a/doc/src/config/setup/browser-extension.md
+++ b/doc/src/config/setup/browser-extension.md
@@ -1,0 +1,101 @@
+# Browser Extension
+
+The Universal Inbox browser extension enhances the integration between your browser and Universal Inbox. It provides two key capabilities:
+
+## Features
+
+### 1. Send Web Pages as Notifications
+
+Send any web page you're viewing to your Universal Inbox as a notification. This lets you capture interesting articles, documentation, or any web content for later processing.
+
+### 2. Slack Bridge (2-Way Sync)
+
+The browser extension bridges the gap between Universal Inbox and Slack's private API, enabling actions that aren't possible through Slack's public API:
+
+- **Mark as Read**: When you delete a Slack thread notification in Universal Inbox, the extension marks the thread as read in Slack
+- **Unsubscribe**: When you unsubscribe from a Slack thread notification, the extension unsubscribes you from the thread in Slack
+
+#### How the Slack Bridge Works
+
+```text
+Universal Inbox                    Browser Extension                  Slack
+     |                                   |                              |
+     | 1. Delete/Unsubscribe             |                              |
+     |    notification                   |                              |
+     |                                   |                              |
+     | 2. Queue pending action           |                              |
+     |                                   |                              |
+     |          3. Poll for actions      |                              |
+     |<----------------------------------|                              |
+     |                                   |                              |
+     |          4. Return pending actions|                              |
+     |---------------------------------->|                              |
+     |                                   |                              |
+     |                                   | 5. Execute via private API   |
+     |                                   |----------------------------->|
+     |                                   |                              |
+     |          6. Report success/failure|                              |
+     |<----------------------------------|                              |
+```
+
+1. You perform a delete or unsubscribe action on a Slack thread notification in Universal Inbox
+2. Universal Inbox queues the action as a "pending action" (only when extension bridge is enabled)
+3. The browser extension polls Universal Inbox every 30 seconds for pending actions
+4. Universal Inbox returns any pending actions, matching them by Slack team ID
+5. The extension executes the action using Slack's private API through your authenticated browser session
+6. The extension reports success or failure back to Universal Inbox
+
+#### Requirements
+
+- The extension must be installed and running in a browser where you are logged into Slack
+- The extension bridge must be enabled in the [Slack integration settings](slack.md) under the "Extension" tab
+- The Slack workspace in the browser must match the workspace connected in Universal Inbox
+
+#### Supported Actions
+
+ Universal Inbox Action | Slack Effect |
+:-: | :-: |
+ Delete (thread notification) | Mark thread as read |
+ Unsubscribe (thread notification) | Unsubscribe from thread |
+
+## Installation
+
+### Firefox
+
+1. Download the extension from the [Universal Inbox releases page](https://github.com/universal-inbox/universal-inbox-extension/releases)
+2. Open `about:addons` in Firefox
+3. Click the gear icon and select "Install Add-on From File..."
+4. Select the downloaded `.xpi` file
+
+### Chrome
+
+1. Download the extension from the [Universal Inbox releases page](https://github.com/universal-inbox/universal-inbox-extension/releases)
+2. Open `chrome://extensions` in Chrome
+3. Enable "Developer mode" in the top right
+4. Click "Load unpacked" and select the extracted extension directory
+
+## Configuration
+
+After installation, open the extension options to configure:
+
+1. **API URL**: Set to your Universal Inbox instance URL (defaults to `https://app.universal-inbox.com`)
+2. **Slack Bridge**: Enable the bridge in the Slack integration settings under the "Extension" tab
+
+## Troubleshooting
+
+### Extension not detected
+
+- Verify the extension is installed and enabled in your browser
+- Check that you are logged into Slack in the same browser
+- Reload the extension from the browser's extension management page
+
+### Team credential mismatch
+
+- Ensure you are logged into the correct Slack workspace in the browser
+- The workspace must match the one connected in Universal Inbox's Slack integration
+
+### Actions failing
+
+- Check the browser console for error messages from the extension
+- Verify your Slack session hasn't expired (try refreshing Slack in the browser)
+- Check that the extension has the necessary permissions

--- a/doc/src/config/setup/slack.md
+++ b/doc/src/config/setup/slack.md
@@ -56,3 +56,7 @@ With the Slack integration, you can:
 - View reactions and mentions in one place
 - Convert these items into tasks with proper due dates
 - Complete tasks directly from Universal Inbox
+
+## Browser Extension Bridge
+
+For Slack thread notifications (from mentions), you can enable the [browser extension bridge](browser-extension.md) to propagate delete and unsubscribe actions back to Slack. This enables 2-way sync between Universal Inbox and Slack threads, which isn't possible through Slack's public API alone.

--- a/doc/src/how/actions/slack.md
+++ b/doc/src/how/actions/slack.md
@@ -33,7 +33,7 @@ This action lets you view the full message context in Slack, where you can respo
 Use this action when you want to clear a notification from your Universal Inbox. The notification will reappear if there's a new reply in the thread for notifications from a Slack mention.
 
 ```admonish note
-Due to Slack API limitations, the read status of a message cannot be changed in Slack. The "Delete" action will only update the status in Universal Inbox.
+Due to Slack API limitations, the read status of a message cannot be changed through the public API. When the [browser extension bridge](../../config/setup/browser-extension.md) is enabled, the extension will mark the thread as read in Slack using your browser session.
 ```
 
 #### Unsubscribe
@@ -43,7 +43,7 @@ Due to Slack API limitations, the read status of a message cannot be changed in 
 - **Effect in Slack**: Remove the reaction from the message. It does not mark the message as read, nor unsubscribe the Slack thread for notifications from Slack mentions.
 
 ```admonish note
-Due to Slack API limitations, the read and subscription status of a message/thread cannot be changed in Slack. The "Unsubscribe" action will only update the status in Universal Inbox.
+Due to Slack API limitations, the subscription status of a thread cannot be changed through the public API. When the [browser extension bridge](../../config/setup/browser-extension.md) is enabled, the extension will unsubscribe you from the thread in Slack using your browser session.
 ```
 
 #### Snooze

--- a/src/integration_connection/integrations/slack.rs
+++ b/src/integration_connection/integrations/slack.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use slack_morphism::{SlackReactionName, SlackTeamId};
 
@@ -23,6 +24,8 @@ pub struct SlackMessageConfig {
     // Keeping it for now as the logic is already implemented and it
     // might be possible to workaround this limitation in the future
     pub is_2way_sync: bool,
+    #[serde(default)]
+    pub extension_enabled: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq)]
@@ -43,6 +46,7 @@ impl Default for SlackConfig {
             message_config: SlackMessageConfig {
                 sync_enabled: false,
                 is_2way_sync: false,
+                extension_enabled: true,
             },
         }
     }
@@ -59,6 +63,7 @@ impl SlackConfig {
             message_config: SlackMessageConfig {
                 sync_enabled: true,
                 is_2way_sync: false,
+                extension_enabled: true,
             },
         }
     }
@@ -73,6 +78,7 @@ impl SlackConfig {
             message_config: SlackMessageConfig {
                 sync_enabled: false,
                 is_2way_sync: false,
+                extension_enabled: true,
             },
         }
     }
@@ -87,6 +93,7 @@ impl SlackConfig {
             message_config: SlackMessageConfig {
                 sync_enabled: false,
                 is_2way_sync: false,
+                extension_enabled: false,
             },
         }
     }
@@ -110,6 +117,16 @@ impl Default for SlackSyncTaskConfig {
 }
 
 #[derive(Deserialize, Serialize, PartialEq, Eq, Debug, Clone)]
+pub struct SlackExtensionCredential {
+    pub team_id: SlackTeamId,
+    pub user_id: String,
+}
+
+#[derive(Deserialize, Serialize, PartialEq, Eq, Debug, Clone)]
 pub struct SlackContext {
     pub team_id: SlackTeamId,
+    #[serde(default)]
+    pub extension_credentials: Vec<SlackExtensionCredential>,
+    #[serde(default)]
+    pub last_extension_heartbeat_at: Option<DateTime<Utc>>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ extern crate enum_derive;
 pub mod auth;
 pub mod integration_connection;
 pub mod notification;
+pub mod slack_bridge;
 pub mod task;
 pub mod third_party;
 pub mod typed_id;

--- a/src/slack_bridge/mod.rs
+++ b/src/slack_bridge/mod.rs
@@ -1,0 +1,84 @@
+use std::{fmt, str::FromStr};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use slack_morphism::prelude::*;
+use uuid::Uuid;
+
+use crate::{notification::NotificationId, user::UserId};
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Copy, Clone, Eq, Hash)]
+#[serde(transparent)]
+pub struct SlackBridgePendingActionId(pub Uuid);
+
+impl fmt::Display for SlackBridgePendingActionId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<Uuid> for SlackBridgePendingActionId {
+    fn from(id: Uuid) -> Self {
+        Self(id)
+    }
+}
+
+impl From<SlackBridgePendingActionId> for Uuid {
+    fn from(id: SlackBridgePendingActionId) -> Self {
+        id.0
+    }
+}
+
+impl FromStr for SlackBridgePendingActionId {
+    type Err = uuid::Error;
+
+    fn from_str(uuid: &str) -> Result<Self, Self::Err> {
+        Ok(Self(Uuid::parse_str(uuid)?))
+    }
+}
+
+macro_attr! {
+    #[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq, EnumFromStr!, EnumDisplay!)]
+    pub enum SlackBridgeActionType {
+        MarkAsRead,
+        Unsubscribe,
+    }
+}
+
+macro_attr! {
+    #[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq, EnumFromStr!, EnumDisplay!)]
+    pub enum SlackBridgeActionStatus {
+        Pending,
+        Completed,
+        Failed,
+        PermanentlyFailed,
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SlackBridgePendingAction {
+    pub id: SlackBridgePendingActionId,
+    pub user_id: UserId,
+    pub notification_id: Option<NotificationId>,
+    pub action_type: SlackBridgeActionType,
+    pub slack_team_id: SlackTeamId,
+    pub slack_channel_id: SlackChannelId,
+    pub slack_thread_ts: SlackTs,
+    pub slack_last_message_ts: SlackTs,
+    pub status: SlackBridgeActionStatus,
+    pub failure_message: Option<String>,
+    pub retry_count: i32,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub completed_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SlackBridgeStatus {
+    pub extension_connected: bool,
+    pub team_id_match: bool,
+    pub user_id_match: bool,
+    pub pending_actions_count: i64,
+    pub failed_actions_count: i64,
+    pub last_completed_at: Option<DateTime<Utc>>,
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -589,6 +589,7 @@
       "integrity": "sha512-ifjHqLczC81d1xjXPXCzxTFKNOFsEzuuLN44cMnyzQ/GWi4B48fyX7JHndWE7Lxd54cW1O9Ik7AdBN3Gq891EA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/runtime-tools": "0.18.0",
         "@rspack/binding": "1.5.2",
@@ -910,6 +911,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3344,7 +3346,8 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.13.tgz",
       "integrity": "sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/thingies": {
       "version": "2.5.0",
@@ -3432,7 +3435,8 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/type-is": {
       "version": "1.6.18",

--- a/web/src/components/footer.rs
+++ b/web/src/components/footer.rs
@@ -10,7 +10,7 @@ use universal_inbox::{
     IntegrationProviderStaticConfig,
     integration_connection::{
         IntegrationConnection, IntegrationConnectionStatus as ConnectionStatus,
-        provider::IntegrationProviderKind,
+        provider::{IntegrationProvider, IntegrationProviderKind},
     },
 };
 
@@ -57,14 +57,45 @@ pub fn Footer() -> Element {
             }
         });
         if has_missing_permission {
-            (
+            return (
                 Some("Some integrations are missing permissions, please reconnect them."),
                 "bg-warning text-warning-content",
                 "",
-            )
-        } else {
-            (None, "", "max-sm:hidden")
+            );
         }
+        let has_slack_extension_enabled = integration_connections.iter().any(|c| {
+            matches!(
+                &c.provider,
+                IntegrationProvider::Slack {
+                    config,
+                    ..
+                } if config.message_config.extension_enabled
+            )
+        });
+        if has_slack_extension_enabled {
+            // Check if the extension has a recent heartbeat via context
+            let extension_not_detected = integration_connections.iter().any(|c| {
+                matches!(
+                    &c.provider,
+                    IntegrationProvider::Slack {
+                        context: Some(ctx),
+                        config,
+                        ..
+                    } if config.message_config.extension_enabled
+                        && ctx.last_extension_heartbeat_at
+                            .map(|hb| (chrono::Utc::now() - hb).num_seconds() > 120)
+                            .unwrap_or(true)
+                )
+            });
+            if extension_not_detected {
+                return (
+                    Some("Slack browser extension not detected. Install or check it is running."),
+                    "bg-warning text-warning-content",
+                    "",
+                );
+            }
+        }
+        (None, "", "max-sm:hidden")
     })();
 
     rsx! {

--- a/web/src/components/integrations/slack/config.rs
+++ b/web/src/components/integrations/slack/config.rs
@@ -3,18 +3,26 @@
 use dioxus::prelude::dioxus_core::use_drop;
 use dioxus::prelude::*;
 use dioxus::web::WebEventExt;
-use dioxus_free_icons::{Icon, icons::bs_icons::BsChatText};
+use dioxus_free_icons::{
+    Icon,
+    icons::bs_icons::{BsChatText, BsPuzzle},
+};
+use log::error;
+use reqwest::Method;
 use serde_json::json;
 use slack_morphism::SlackReactionName;
+
+use chrono::{Local, SecondsFormat};
 
 use universal_inbox::{
     integration_connection::{
         config::IntegrationConnectionConfig,
         integrations::slack::{
-            SlackConfig, SlackMessageConfig, SlackReactionConfig, SlackSyncTaskConfig,
-            SlackSyncType,
+            SlackConfig, SlackContext, SlackMessageConfig, SlackReactionConfig,
+            SlackSyncTaskConfig, SlackSyncType,
         },
     },
+    slack_bridge::SlackBridgeStatus,
     task::{PresetDueDate, ProjectSummary, TaskPriority},
     utils::emoji::replace_emoji_code_with_emoji,
 };
@@ -26,12 +34,17 @@ use crate::{
     },
     config::get_api_base_url,
     model::UniversalInboxUIModel,
-    services::flyonui::{forget_flyonui_tabs_element, init_flyonui_tabs_element},
+    services::{
+        api::call_api,
+        flyonui::{forget_flyonui_tabs_element, init_flyonui_tabs_element},
+    },
 };
 
 #[component]
 pub fn SlackProviderConfiguration(
     config: ReadSignal<SlackConfig>,
+    context: ReadSignal<Option<Option<SlackContext>>>,
+    provider_user_id: ReadSignal<Option<Option<String>>>,
     ui_model: Signal<UniversalInboxUIModel>,
     on_config_change: EventHandler<IntegrationConnectionConfig>,
 ) -> Element {
@@ -75,6 +88,15 @@ pub fn SlackProviderConfiguration(
                     Icon { class: "h-5 w-5 min-w-5", icon: BsChatText },
                     span { "Mention" }
                 }
+
+                button {
+                    class: "tab active-tab:tab-active flex items-center gap-2 rounded-b-none",
+                    "type": "button",
+                    role: "tab",
+                    "data-tab": "#slack-config-tab-extension",
+                    Icon { class: "h-5 w-5 min-w-5", icon: BsPuzzle },
+                    span { "Extension" }
+                }
             }
 
             div {
@@ -90,6 +112,13 @@ pub fn SlackProviderConfiguration(
                     role: "tabpanel",
                     class: "bg-base-100 border-base-300 p-6 rounded-b-md flex flex-col gap-2 hidden",
                     SlackMessageConfiguration { config, ui_model, on_config_change }
+                }
+
+                div {
+                    id: "slack-config-tab-extension",
+                    role: "tabpanel",
+                    class: "bg-base-100 border-base-300 p-6 rounded-b-md flex flex-col gap-2 hidden",
+                    SlackExtensionConfiguration { config, context, provider_user_id, on_config_change }
                 }
             }
         }
@@ -415,6 +444,175 @@ fn SlackMessageConfiguration(
                 }
                 span {
                     class: "icon-[tabler--x] text-neutral absolute end-1 top-1 block size-4 peer-checked:hidden"
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn SlackExtensionConfiguration(
+    config: ReadSignal<SlackConfig>,
+    context: ReadSignal<Option<Option<SlackContext>>>,
+    provider_user_id: ReadSignal<Option<Option<String>>>,
+    on_config_change: EventHandler<IntegrationConnectionConfig>,
+) -> Element {
+    let slack_context = context().flatten();
+    let expected_user_id = provider_user_id().flatten();
+    let extension_enabled = config().message_config.extension_enabled;
+
+    let bridge_status = use_resource(move || async move {
+        if !extension_enabled {
+            return None;
+        }
+        let api_base_url = get_api_base_url().ok()?;
+        let result: Result<SlackBridgeStatus, _> = call_api(
+            Method::GET,
+            &api_base_url,
+            "slack-bridge/status",
+            None::<()>,
+            None,
+        )
+        .await;
+        match result {
+            Ok(status) => Some(status),
+            Err(err) => {
+                error!("Failed to fetch bridge status: {err}");
+                None
+            }
+        }
+    });
+
+    rsx! {
+        div {
+            class: "flex items-center gap-2",
+
+            label {
+                class: "label-text cursor-pointer grow text-sm text-base-content",
+                "Enable browser extension bridge for Slack actions"
+            }
+            div {
+                class: "relative inline-block",
+                input {
+                    r#type: "checkbox",
+                    class: "switch switch-primary switch-outline peer",
+                    oninput: move |event| {
+                        on_config_change.call(IntegrationConnectionConfig::Slack(SlackConfig {
+                            message_config: SlackMessageConfig {
+                                extension_enabled: event.value() == "true",
+                                ..config().message_config
+                            },
+                            ..config()
+                        }))
+                    },
+                    checked: config().message_config.extension_enabled
+                }
+                span {
+                    class: "icon-[tabler--check] text-primary absolute start-1 top-1 hidden size-4 peer-checked:block"
+                }
+                span {
+                    class: "icon-[tabler--x] text-neutral absolute end-1 top-1 block size-4 peer-checked:hidden"
+                }
+            }
+        }
+
+        p {
+            class: "text-xs text-base-content/60",
+            "When enabled, deleting or unsubscribing from Slack thread notifications will "
+            "queue actions for the browser extension to execute using your Slack session."
+        }
+
+        if extension_enabled {
+            div {
+                class: "mt-4 flex flex-col gap-2 rounded-md bg-base-200 p-3 text-xs",
+
+                div {
+                    class: "flex items-center gap-2",
+                    span { class: "font-medium text-base-content/70", "Last heartbeat:" }
+                    if let Some(ref ctx) = slack_context {
+                        if let Some(heartbeat) = ctx.last_extension_heartbeat_at {
+                            {
+                                let age_secs = (chrono::Utc::now() - heartbeat).num_seconds();
+                                let is_stale = age_secs > 120;
+                                let formatted = heartbeat
+                                    .with_timezone(&Local)
+                                    .to_rfc3339_opts(SecondsFormat::Secs, true);
+                                rsx! {
+                                    span {
+                                        class: if is_stale { "text-warning" } else { "text-success" },
+                                        "{formatted} ({age_secs}s ago)"
+                                    }
+                                }
+                            }
+                        } else {
+                            span { class: "text-warning", "No heartbeat detected" }
+                        }
+                    } else {
+                        span { class: "text-base-content/50", "No extension data available" }
+                    }
+                }
+
+                if let Some(Some(ref status)) = *bridge_status.read() {
+                    div {
+                        class: "flex items-center gap-2",
+                        span { class: "font-medium text-base-content/70", "Connection status:" }
+                        if !status.extension_connected {
+                            span { class: "text-warning",
+                                "Extension not polling. Check it is installed and running."
+                            }
+                        } else if let Some(ref ctx) = slack_context {
+                            if ctx.extension_credentials.is_empty() {
+                                span { class: "text-warning",
+                                    "Extension is polling but no Slack tab detected. Open app.slack.com in your browser, or grant the extension permission to access the tab."
+                                }
+                            } else if !status.team_id_match {
+                                {
+                                    let ext_teams = ctx.extension_credentials.iter()
+                                        .map(|c| c.team_id.0.as_str())
+                                        .collect::<Vec<_>>().join(", ");
+                                    rsx! {
+                                        span { class: "text-warning",
+                                            "Workspace mismatch: extension sees team {ext_teams}, but the integration expects {ctx.team_id.0}."
+                                        }
+                                    }
+                                }
+                            } else if !status.user_id_match {
+                                {
+                                    let matching_cred = ctx.extension_credentials.iter()
+                                        .find(|c| c.team_id == ctx.team_id);
+                                    let ext_uid = matching_cred.map(|c| c.user_id.as_str()).unwrap_or("unknown");
+                                    let expected_uid = expected_user_id.as_deref().unwrap_or("unknown");
+                                    rsx! {
+                                        span { class: "text-warning",
+                                            "User mismatch: extension sees user {ext_uid}, but the integration expects {expected_uid}."
+                                        }
+                                    }
+                                }
+                            } else {
+                                span { class: "text-success", "Connected and ready" }
+                            }
+                        } else {
+                            span { class: "text-base-content/50", "No extension data available" }
+                        }
+                    }
+
+                    div {
+                        class: "flex items-center gap-2",
+                        span { class: "font-medium text-base-content/70", "Pending actions:" }
+                        span {
+                            class: "text-base-content",
+                            "{status.pending_actions_count}"
+                        }
+                    }
+
+                    div {
+                        class: "flex items-center gap-2",
+                        span { class: "font-medium text-base-content/70", "Failed actions (retrying):" }
+                        span {
+                            class: if status.failed_actions_count > 0 { "text-warning" } else { "text-base-content" },
+                            "{status.failed_actions_count}"
+                        }
+                    }
                 }
             }
         }

--- a/web/src/components/integrations_panel.rs
+++ b/web/src/components/integrations_panel.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use chrono::{Local, SecondsFormat};
+use chrono::{Local, SecondsFormat, TimeDelta, Utc};
 use dioxus::prelude::*;
 use dioxus_free_icons::{
     Icon,
@@ -301,6 +301,62 @@ pub fn IntegrationSettings(
         _ => None,
     })();
 
+    let extension_bridge_message = use_memo(move || {
+        let Some(Some(ref ic)) = connection() else {
+            return None;
+        };
+        let IntegrationProvider::Slack {
+            config: ref slack_config,
+            context: Some(ref ctx),
+        } = ic.provider
+        else {
+            return None;
+        };
+        if !slack_config.message_config.extension_enabled {
+            return None;
+        }
+        let heartbeat_fresh = ctx
+            .last_extension_heartbeat_at
+            .map(|hb| Utc::now() - hb < TimeDelta::seconds(120))
+            .unwrap_or(false);
+        if !heartbeat_fresh {
+            return Some(
+                "🟡 Browser extension not polling. Check it is installed and running.".to_string(),
+            );
+        }
+        if ctx.extension_credentials.is_empty() {
+            return Some(
+                "🟡 Browser extension polling but no Slack tab detected. Open app.slack.com or grant the extension permission to access the tab.".to_string(),
+            );
+        }
+        let matching_cred = ctx
+            .extension_credentials
+            .iter()
+            .find(|c| c.team_id == ctx.team_id);
+        if matching_cred.is_none() {
+            let ext_teams = ctx
+                .extension_credentials
+                .iter()
+                .map(|c| c.team_id.0.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Some(format!(
+                "🟡 Browser extension workspace mismatch. Extension sees team {ext_teams}, expected {}.",
+                ctx.team_id.0
+            ));
+        }
+        let matching_cred = matching_cred.unwrap();
+        if let Some(ref expected_uid) = ic.provider_user_id
+            && matching_cred.user_id != *expected_uid
+        {
+            return Some(format!(
+                "🟡 Browser extension user mismatch. Extension sees user {}, expected {expected_uid}.",
+                matching_cred.user_id
+            ));
+        }
+        Some("🟢 Browser extension connected and ready.".to_string())
+    })();
+
     let has_all_oauth_scopes = use_memo(move || {
         if let Some(Some(ic)) = connection() {
             let result = ic.has_oauth_scopes(&config().required_oauth_scopes);
@@ -381,7 +437,10 @@ pub fn IntegrationSettings(
                     if let Some(tasks_sync_message) = &tasks_sync_message {
                         span { "{tasks_sync_message}" }
                     }
-                    if notifications_sync_message.is_none() && tasks_sync_message.is_none() {
+                    if let Some(extension_bridge_message) = &extension_bridge_message {
+                        span { "{extension_bridge_message}" }
+                    }
+                    if notifications_sync_message.is_none() && tasks_sync_message.is_none() && extension_bridge_message.is_none() {
                         span { }
                     }
                 }
@@ -426,10 +485,16 @@ pub fn IntegrationSettings(
 
                 if let Some(provider) = provider {
                     if let Some(Some(connection)) = connection() {
-                        IntegrationConnectionProviderConfiguration {
-                            ui_model: ui_model,
-                            on_config_change: move |c| on_config_change.call((connection.clone(), c)),
-                            provider: provider.clone(),
+                        {
+                            let provider_user_id = connection.provider_user_id.clone();
+                            rsx! {
+                                IntegrationConnectionProviderConfiguration {
+                                    ui_model: ui_model,
+                                    on_config_change: move |c| on_config_change.call((connection.clone(), c)),
+                                    provider: provider.clone(),
+                                    provider_user_id,
+                                }
+                            }
                         }
                     }
                 }
@@ -459,6 +524,7 @@ pub fn IconForAction(action: String) -> Element {
 #[component]
 pub fn IntegrationConnectionProviderConfiguration(
     provider: IntegrationProvider,
+    provider_user_id: ReadSignal<Option<Option<String>>>,
     ui_model: Signal<UniversalInboxUIModel>,
     on_config_change: EventHandler<IntegrationConnectionConfig>,
 ) -> Element {
@@ -501,11 +567,13 @@ pub fn IntegrationConnectionProviderConfiguration(
                 config: config.clone()
             }
         },
-        IntegrationProvider::Slack { config, .. } => rsx! {
+        IntegrationProvider::Slack { config, context } => rsx! {
             SlackProviderConfiguration {
                 ui_model: ui_model,
                 on_config_change: move |c| on_config_change.call(c),
                 config: config.clone(),
+                context: context.clone(),
+                provider_user_id,
             }
         },
         _ => rsx! {},


### PR DESCRIPTION
## Summary

- Implements the Slack bridge pending action system for 2-way sync between Universal Inbox and Slack via a browser extension
- Extension polls for queued actions (mark-as-read, unsubscribe) and executes them through Slack's private API using the user's authenticated browser session
- Adds credential validation: the extension sends live `team_id` + `user_id` pairs extracted from open Slack tabs, matched against the integration connection
- Three-state action lifecycle: Pending → Failed (with exponential backoff retry) → PermanentlyFailed
- Browser extension status displayed on the integration card (next to sync status) and in the Extension settings tab with actionable error messages
- Extension bridge enabled by default for new Slack integration connections

## Test plan

- [ ] Create a Slack integration connection and verify `extension_enabled` defaults to `true`
- [ ] Install the browser extension, open Slack in browser → verify heartbeat and credentials appear in settings
- [ ] Delete a Slack thread notification → verify a pending action is created
- [ ] Verify the extension picks up and executes the action via Slack's private API
- [ ] Close the Slack tab → verify the UI shows "no Slack tab detected" warning
- [ ] Log into a different Slack user → verify user mismatch warning with expected vs actual IDs
- [ ] Simulate action failure → verify retry with exponential backoff, then PermanentlyFailed after max retries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/universal-inbox/universal-inbox/pull/149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Slack browser-extension bridge for two‑way delete/unsubscribe sync and a Slack Bridge status view in integration settings; footer shows extension detection/heartbeat.

* **Documentation**
  * New browser extension setup guide and updated Slack docs clarifying action effects and extension workflow.

* **Behavior Changes**
  * Removed support for Slack “saved for later” (star) items; Slack reactions and thread notifications remain.

* **Chores**
  * Removed Slack OAuth scopes for stars (stars:read, stars:write).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->