### PR TITLE
fix: Fix Google Mail URLs and Google Drive comments API

### DIFF
--- a/api/src/integrations/google_drive.rs
+++ b/api/src/integrations/google_drive.rs
@@ -279,10 +279,7 @@ impl GoogleDriveService {
             [
                 format!("{}/about", self.google_drive_base_path),
                 format!("{}/files", self.google_drive_base_path),
-                format!(
-                    "{}/files/{{commment_id}}/comments",
-                    self.google_drive_base_path
-                ),
+                format!("{}/files/{{file_id}}/comments", self.google_drive_base_path),
             ],
             self.max_retry_duration,
         )
@@ -336,7 +333,7 @@ impl GoogleDriveService {
 
         loop {
             let comments_url = format!(
-                "{}/files/{}/comments?pageSize={}&fields=comments(id,content,htmlContent,quotedFileContent,author,createdTime,modifiedTime,resolved,replies),nextPageToken{}",
+                "{}/files/{}/comments?supportsAllDrives=true&pageSize={}&fields=comments(id,content,htmlContent,quotedFileContent,author,createdTime,modifiedTime,resolved,replies),nextPageToken{}",
                 self.google_drive_base_url,
                 file_id,
                 self.page_size,

--- a/api/src/integrations/google_mail.rs
+++ b/api/src/integrations/google_mail.rs
@@ -1080,7 +1080,7 @@ mod tests {
             );
             assert_eq!(
                 google_mail_notification.get_html_url(),
-                "https://mail.google.com/mail/u/test@example.com/#inbox/18a909f8178"
+                "https://mail.google.com/mail/u/0/?authuser=test@example.com#all/18a909f8178"
                     .parse::<Url>()
                     .unwrap()
             );
@@ -1154,7 +1154,7 @@ mod tests {
             assert_eq!(google_mail_notification.title, DEFAULT_SUBJECT.to_string());
             assert_eq!(
                 google_mail_notification.get_html_url(),
-                "https://mail.google.com/mail/u/test@example.com/#inbox/18a909f8178"
+                "https://mail.google.com/mail/u/0/?authuser=test@example.com#all/18a909f8178"
                     .parse::<Url>()
                     .unwrap()
             );

--- a/api/tests/api/helpers/notification/google_drive.rs
+++ b/api/tests/api/helpers/notification/google_drive.rs
@@ -124,6 +124,7 @@ pub async fn mock_google_drive_comments_list_service(
     let mut mock_builder = Mock::given(method("GET"))
         .and(path(format!("/files/{}/comments", file_id)))
         .and(header("authorization", "Bearer google_drive_test_access_token"))
+        .and(query_param("supportsAllDrives", "true"))
         .and(query_param("pageSize", per_page.to_string()))
         .and(query_param(
             "fields",

--- a/api/tests/api/helpers/notification/google_mail.rs
+++ b/api/tests/api/helpers/notification/google_mail.rs
@@ -295,7 +295,7 @@ pub fn assert_sync_notifications(
                 assert_eq!(notification.status, NotificationStatus::Unread);
                 assert_eq!(
                     notification.get_html_url(),
-                    "https://mail.google.com/mail/u/user@example.com/#inbox/123"
+                    "https://mail.google.com/mail/u/0/?authuser=user@example.com#all/123"
                         .parse::<Url>()
                         .unwrap()
                 );
@@ -312,7 +312,7 @@ pub fn assert_sync_notifications(
                 assert_eq!(notification.status, NotificationStatus::Read);
                 assert_eq!(
                     notification.get_html_url(),
-                    "https://mail.google.com/mail/u/user@example.com/#inbox/456"
+                    "https://mail.google.com/mail/u/0/?authuser=user@example.com#all/456"
                         .parse::<Url>()
                         .unwrap()
                 );

--- a/src/third_party/integrations/google_mail.rs
+++ b/src/third_party/integrations/google_mail.rs
@@ -202,7 +202,7 @@ impl ThirdPartyItemFromSource for GoogleMailThread {
 impl HasHtmlUrl for GoogleMailThread {
     fn get_html_url(&self) -> Url {
         format!(
-            "https://mail.google.com/mail/u/{}/#inbox/{}",
+            "https://mail.google.com/mail/u/0/?authuser={}#all/{}",
             self.user_email_address, self.id
         )
         .parse::<Url>()


### PR DESCRIPTION
## Summary

- **Gmail URL fix**: Change URL format from `/u/{email}/#inbox/{id}` to `/u/0/?authuser={email}#all/{id}` to fix 404 errors when opening emails in Gmail
- **Google Drive comments fix**: Add `supportsAllDrives=true` to the comments endpoint to fix 404 errors when fetching comments on shared drive files
- **OTel path template typo**: Fix `commment_id` → `file_id` in known paths

## Test plan

- [x] All Google Mail unit and integration tests pass (21/21)
- [x] All Google Drive unit and integration tests pass (16/16)
- [x] `cargo clippy --tests` passes with no warnings
- [ ] Manual verification: click a Gmail notification link and confirm it opens the correct thread
- [ ] Manual verification: confirm Google Drive comment sync works for shared drive files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/universal-inbox/universal-inbox/pull/150" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed Google Drive comments endpoint to use correct file ID parameter
  * Added support for shared drives in Google Drive comments requests
  * Corrected Google Mail notification URL format to use updated Gmail link structure

* **Tests**
  * Updated test expectations for Google Drive and Google Mail notification URLs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->