### PR TITLE
feat: Add OTEL tracing attributes to Slack webhook pipeline

### DIFF
--- a/api/src/integrations/slack.rs
+++ b/api/src/integrations/slack.rs
@@ -13,6 +13,7 @@ use slack_morphism::{
 use sqlx::{Postgres, Transaction};
 use tokio::sync::RwLock;
 use tracing::{debug, warn};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 use url::Url;
 use uuid::Uuid;
 use vec1::Vec1;
@@ -389,12 +390,16 @@ impl SlackService {
     }
 
     #[allow(clippy::blocks_in_conditions)]
+    #[tracing::instrument(level = "debug", skip_all, err)]
     pub async fn fetch_item_from_event(
         &self,
         executor: &mut Transaction<'_, Postgres>,
         slack_push_event_callback: &SlackPushEventCallback,
         user_id: UserId,
     ) -> Result<Option<ThirdPartyItem>, UniversalInboxError> {
+        let current_span = tracing::Span::current();
+        current_span.set_attribute("user.id", user_id.to_string());
+
         match &slack_push_event_callback.event {
             SlackEventCallbackBody::ReactionAdded(SlackReactionAddedEvent {
                 item,
@@ -403,6 +408,7 @@ impl SlackService {
                 event_ts,
                 ..
             }) => {
+                current_span.set_attribute("slack.fetch.item_type", "slack_reaction");
                 self.fetch_item_from_slack_reaction(
                     executor,
                     slack_push_event_callback,
@@ -422,6 +428,7 @@ impl SlackService {
                 event_ts,
                 ..
             }) => {
+                current_span.set_attribute("slack.fetch.item_type", "slack_reaction");
                 self.fetch_item_from_slack_reaction(
                     executor,
                     slack_push_event_callback,
@@ -435,6 +442,7 @@ impl SlackService {
                 .await
             }
             SlackEventCallbackBody::Message(SlackMessageEvent { origin, .. }) => {
+                current_span.set_attribute("slack.fetch.item_type", "slack_thread");
                 self.fetch_item_from_slack_message(
                     executor,
                     slack_push_event_callback,
@@ -444,7 +452,11 @@ impl SlackService {
                 .await
             }
             // Not yet implemented resource type
-            _ => Ok(None),
+            _ => {
+                current_span.set_attribute("slack.fetch.outcome", "skipped");
+                current_span.set_attribute("slack.fetch.skip_reason", "unsupported_event_type");
+                Ok(None)
+            }
         }
     }
 
@@ -509,6 +521,7 @@ impl SlackService {
     }
 
     #[allow(clippy::blocks_in_conditions, clippy::too_many_arguments)]
+    #[tracing::instrument(level = "debug", skip_all, err)]
     pub async fn fetch_item_from_slack_reaction(
         &self,
         executor: &mut Transaction<'_, Postgres>,
@@ -520,6 +533,10 @@ impl SlackService {
         slack_reaction_name: &SlackReactionName,
         user_id: UserId,
     ) -> Result<Option<ThirdPartyItem>, UniversalInboxError> {
+        let current_span = tracing::Span::current();
+        current_span.set_attribute("user.id", user_id.to_string());
+        current_span.set_attribute("slack.reaction_name", slack_reaction_name.to_string());
+
         let (access_token, integration_connection) = self
             .integration_connection_service
             .read()
@@ -589,16 +606,26 @@ impl SlackService {
             SlackReactionsItem::Message(SlackHistoryMessage {
                 origin: SlackMessageOrigin { channel: None, .. },
                 ..
-            })
-            | SlackReactionsItem::File(_) => return Ok(None),
+            }) => {
+                current_span.set_attribute("slack.fetch.outcome", "skipped");
+                current_span.set_attribute("slack.fetch.skip_reason", "no_channel");
+                return Ok(None);
+            }
+            SlackReactionsItem::File(_) => {
+                current_span.set_attribute("slack.fetch.outcome", "skipped");
+                current_span.set_attribute("slack.fetch.skip_reason", "file_reaction");
+                return Ok(None);
+            }
         };
 
+        current_span.set_attribute("slack.fetch.outcome", "fetched");
         Ok(Some(
             slack_reaction.into_third_party_item(user_id, integration_connection.id),
         ))
     }
 
     #[allow(clippy::blocks_in_conditions, clippy::too_many_arguments)]
+    #[tracing::instrument(level = "debug", skip_all, err)]
     pub async fn fetch_item_from_slack_message(
         &self,
         executor: &mut Transaction<'_, Postgres>,
@@ -606,6 +633,9 @@ impl SlackService {
         origin: &SlackMessageOrigin,
         user_id: UserId,
     ) -> Result<Option<ThirdPartyItem>, UniversalInboxError> {
+        let current_span = tracing::Span::current();
+        current_span.set_attribute("user.id", user_id.to_string());
+
         let (access_token, integration_connection) = self
             .integration_connection_service
             .read()
@@ -620,8 +650,11 @@ impl SlackService {
             .with_team_id(slack_push_event_callback.team_id.clone());
 
         let Some(channel_id) = &origin.channel else {
+            current_span.set_attribute("slack.fetch.outcome", "skipped");
+            current_span.set_attribute("slack.fetch.skip_reason", "no_channel_id");
             return Ok(None);
         };
+        current_span.set_attribute("slack.channel_id", channel_id.to_string());
         let root_ts = origin.thread_ts.as_ref().unwrap_or(&origin.ts);
         let messages = self
             .fetch_thread(channel_id, root_ts, &origin.ts, user_id, &slack_api_token)
@@ -674,6 +707,7 @@ impl SlackService {
             user_slack_id: integration_connection.provider_user_id.clone(),
         };
 
+        current_span.set_attribute("slack.fetch.outcome", "fetched");
         Ok(Some(
             slack_thread.into_third_party_item(user_id, integration_connection.id),
         ))

--- a/api/src/jobs/slack/mod.rs
+++ b/api/src/jobs/slack/mod.rs
@@ -6,6 +6,8 @@ use serde::{Deserialize, Serialize};
 use slack_morphism::prelude::*;
 use tokio::sync::RwLock;
 
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
 use crate::{
     integrations::slack::SlackService,
     jobs::slack::{
@@ -35,6 +37,7 @@ pub fn fail_if_needed<T>(
     }
 }
 
+#[tracing::instrument(level = "debug", skip_all, err)]
 pub async fn handle_slack_push_event(
     job: SlackPushEventCallbackJob,
     notification_service: Data<Arc<RwLock<NotificationService>>>,
@@ -43,6 +46,17 @@ pub async fn handle_slack_push_event(
     third_party_item_service: Data<Arc<RwLock<ThirdPartyItemService>>>,
     slack_service: Data<Arc<SlackService>>,
 ) -> Result<(), UniversalInboxError> {
+    let current_span = tracing::Span::current();
+    current_span.set_attribute("slack.team_id", job.0.team_id.to_string());
+    current_span.set_attribute("slack.event_id", job.0.event_id.to_string());
+    let event_type = match &job.0.event {
+        SlackEventCallbackBody::ReactionAdded(_) => "reaction_added",
+        SlackEventCallbackBody::ReactionRemoved(_) => "reaction_removed",
+        SlackEventCallbackBody::Message(_) => "message",
+        _ => "unknown",
+    };
+    current_span.set_attribute("slack.event_type", event_type);
+
     let service = notification_service.read().await;
     let mut transaction = service
         .begin()

--- a/api/src/jobs/slack/slack_message.rs
+++ b/api/src/jobs/slack/slack_message.rs
@@ -5,6 +5,7 @@ use slack_morphism::prelude::*;
 use sqlx::{Postgres, Transaction};
 use tokio::sync::RwLock;
 use tracing::warn;
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use universal_inbox::{
     integration_connection::{
@@ -25,6 +26,7 @@ use crate::{
     },
 };
 
+#[tracing::instrument(level = "debug", skip_all, err)]
 pub async fn handle_slack_message_push_event(
     executor: &mut Transaction<'_, Postgres>,
     event: &SlackPushEventCallback,
@@ -33,6 +35,8 @@ pub async fn handle_slack_message_push_event(
     third_party_item_service: Arc<RwLock<ThirdPartyItemService>>,
     slack_service: Arc<SlackService>,
 ) -> Result<(), UniversalInboxError> {
+    let current_span = tracing::Span::current();
+
     let (provider_user_ids, thread_ts) = match event {
         SlackPushEventCallback {
             team_id,
@@ -80,10 +84,17 @@ pub async fn handle_slack_message_push_event(
             (user_ids, thread_ts.clone())
         }
         _ => {
+            current_span.set_attribute("slack.message.outcome", "discarded");
+            current_span.set_attribute("slack.message.discard_reason", "not_a_message_event");
             warn!("Slack push event is not a message event");
             return Ok(());
         }
     };
+
+    current_span.set_attribute(
+        "slack.referenced_user_count",
+        provider_user_ids.len() as i64,
+    );
 
     let integration_connections = integration_connection_service
         .read()
@@ -98,6 +109,12 @@ pub async fn handle_slack_message_push_event(
         .iter()
         .map(|integration_connection| integration_connection.id)
         .collect::<Vec<_>>();
+
+    current_span.set_attribute(
+        "slack.matched_integration_connections_count",
+        integration_connections.len() as i64,
+    );
+
     for integration_connection in integration_connections {
         handle_slack_message_push_event_if_enabled(
             executor,
@@ -123,6 +140,11 @@ pub async fn handle_slack_message_push_event(
         )
         .await?;
 
+    current_span.set_attribute(
+        "slack.known_thread_items_count",
+        third_party_items.len() as i64,
+    );
+
     for third_party_item in third_party_items.iter() {
         if !handled_integration_connection_ids.contains(&third_party_item.integration_connection_id)
             && let Some(integration_connection) = integration_connection_service
@@ -145,6 +167,7 @@ pub async fn handle_slack_message_push_event(
     Ok(())
 }
 
+#[tracing::instrument(level = "debug", skip_all, err)]
 async fn handle_slack_message_push_event_if_enabled(
     executor: &mut Transaction<'_, Postgres>,
     event: &SlackPushEventCallback,
@@ -152,6 +175,13 @@ async fn handle_slack_message_push_event_if_enabled(
     existing_third_party_item: Option<&ThirdPartyItem>,
     notification_service: Arc<RwLock<NotificationService>>,
 ) -> Result<(), UniversalInboxError> {
+    let current_span = tracing::Span::current();
+    current_span.set_attribute(
+        "slack.integration_connection_id",
+        integration_connection.id.to_string(),
+    );
+    current_span.set_attribute("user.id", integration_connection.user_id.to_string());
+
     let IntegrationProvider::Slack {
         config: slack_config,
         ..
@@ -173,6 +203,7 @@ async fn handle_slack_message_push_event_if_enabled(
         ..
     } = slack_config
     {
+        current_span.set_attribute("slack.message_sync_enabled", true);
         let user_id = integration_connection.user_id;
         notification_service
             .read()
@@ -188,6 +219,8 @@ async fn handle_slack_message_push_event_if_enabled(
                 user_id,
             )
             .await?;
+    } else {
+        current_span.set_attribute("slack.message_sync_enabled", false);
     }
 
     Ok(())

--- a/api/src/jobs/slack/slack_reaction.rs
+++ b/api/src/jobs/slack/slack_reaction.rs
@@ -5,6 +5,7 @@ use slack_morphism::prelude::*;
 use sqlx::{Postgres, Transaction};
 use tokio::sync::RwLock;
 use tracing::warn;
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use universal_inbox::integration_connection::{
     integrations::slack::{SlackConfig, SlackReactionConfig, SlackSyncType},
@@ -18,6 +19,7 @@ use crate::universal_inbox::{
     task::{TaskEventService, service::TaskService},
 };
 
+#[tracing::instrument(level = "debug", skip_all, err)]
 pub async fn handle_slack_reaction_push_event(
     executor: &mut Transaction<'_, Postgres>,
     event: &SlackPushEventCallback,
@@ -26,6 +28,9 @@ pub async fn handle_slack_reaction_push_event(
     task_service: Arc<RwLock<TaskService>>,
     integration_connection_service: Arc<RwLock<IntegrationConnectionService>>,
 ) -> Result<(), UniversalInboxError> {
+    let current_span = tracing::Span::current();
+    current_span.set_attribute("slack.provider_user_id", provider_user_id.clone());
+
     let Some(integration_connection) = integration_connection_service
         .read()
         .await
@@ -36,6 +41,8 @@ pub async fn handle_slack_reaction_push_event(
         )
         .await?
     else {
+        current_span.set_attribute("slack.reaction.outcome", "discarded");
+        current_span.set_attribute("slack.reaction.discard_reason", "no_integration_connection");
         warn!("Validated integration connection not found for Slack user id {provider_user_id}");
         return Ok(());
     };
@@ -53,6 +60,12 @@ pub async fn handle_slack_reaction_push_event(
 
     let user_id = integration_connection.user_id;
     let integration_connection_id = integration_connection.id;
+    current_span.set_attribute("user.id", user_id.to_string());
+    current_span.set_attribute(
+        "slack.integration_connection_id",
+        integration_connection_id.to_string(),
+    );
+
     match slack_config {
         SlackConfig {
             reaction_config:
@@ -62,12 +75,16 @@ pub async fn handle_slack_reaction_push_event(
                     ..
                 },
             ..
-        } => task_service
-            .read()
-            .await
-            .save_task_from_event(executor, event, user_id)
-            .await
-            .map(|_| ()),
+        } => {
+            current_span.set_attribute("slack.sync_type", "as_tasks");
+            current_span.set_attribute("slack.reaction.outcome", "processed");
+            task_service
+                .read()
+                .await
+                .save_task_from_event(executor, event, user_id)
+                .await
+                .map(|_| ())
+        }
 
         SlackConfig {
             reaction_config:
@@ -77,14 +94,20 @@ pub async fn handle_slack_reaction_push_event(
                     ..
                 },
             ..
-        } => notification_service
-            .read()
-            .await
-            .save_notification_from_event(executor, event, None, user_id)
-            .await
-            .map(|_| ()),
+        } => {
+            current_span.set_attribute("slack.sync_type", "as_notifications");
+            current_span.set_attribute("slack.reaction.outcome", "processed");
+            notification_service
+                .read()
+                .await
+                .save_notification_from_event(executor, event, None, user_id)
+                .await
+                .map(|_| ())
+        }
 
         _ => {
+            current_span.set_attribute("slack.reaction.outcome", "discarded");
+            current_span.set_attribute("slack.reaction.discard_reason", "sync_disabled");
             warn!(
                 "Slack reaction sync was not enabled for integration connection {integration_connection_id}"
             );

--- a/api/src/routes/webhook.rs
+++ b/api/src/routes/webhook.rs
@@ -12,6 +12,7 @@ use tokio_retry::{
     strategy::{ExponentialBackoff, jitter},
 };
 use tracing::{debug, warn};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 use universal_inbox::{
     integration_connection::{
         config::IntegrationConnectionConfig,
@@ -35,14 +36,19 @@ pub fn scope() -> Scope {
         .service(web::resource("/slack/events").route(web::post().to(push_slack_event)))
 }
 
+#[tracing::instrument(level = "debug", skip_all, err)]
 pub async fn push_slack_event(
     integration_connection_service: web::Data<Arc<RwLock<IntegrationConnectionService>>>,
     third_party_item_service: web::Data<Arc<RwLock<ThirdPartyItemService>>>,
     slack_push_event: web::Json<SlackPushEvent>,
     storage: web::Data<RedisStorage<UniversalInboxJob>>,
 ) -> Result<HttpResponse, UniversalInboxError> {
+    let current_span = tracing::Span::current();
+
     match slack_push_event.into_inner() {
         SlackPushEvent::UrlVerification(SlackUrlVerificationEvent { challenge }) => {
+            current_span.set_attribute("slack.event_type", "url_verification");
+            current_span.set_attribute("slack.event.outcome", "url_verification");
             return Ok(HttpResponse::Ok()
                 .content_type("application/json")
                 .body(json!({ "challenge": challenge }).to_string()));
@@ -69,50 +75,107 @@ pub async fn push_slack_event(
                 ..
             },
         ) => {
+            let event_type = match &event.event {
+                SlackEventCallbackBody::ReactionAdded(_) => "reaction_added",
+                SlackEventCallbackBody::ReactionRemoved(_) => "reaction_removed",
+                _ => unreachable!(),
+            };
+            current_span.set_attribute("slack.event_type", event_type);
+            current_span.set_attribute("slack.team_id", event.team_id.to_string());
+            current_span.set_attribute("slack.event_id", event.event_id.to_string());
+            current_span.set_attribute("slack.user_id", user.to_string());
+            current_span.set_attribute("slack.reaction", reaction.to_string());
+
             let service = integration_connection_service.read().await;
             let mut transaction = service
                 .begin()
                 .await
                 .context("Failed to create new transaction while checking Slack user ID")?;
 
-            if let Some(IntegrationConnectionConfig::Slack(SlackConfig {
-                reaction_config:
-                    SlackReactionConfig {
-                        sync_enabled: true,
-                        reaction_name,
-                        ..
-                    },
-                ..
-            })) = service
+            let config = service
                 .get_integration_connection_config_for_provider_user_id(
                     &mut transaction,
                     IntegrationProviderKind::Slack,
                     user.to_string(),
                 )
-                .await?
-                && reaction_name == *reaction
-            {
-                send_slack_push_event_callback_job(storage.as_ref(), event.clone()).await?;
+                .await?;
+
+            match config {
+                Some(IntegrationConnectionConfig::Slack(SlackConfig {
+                    reaction_config:
+                        SlackReactionConfig {
+                            sync_enabled: true,
+                            reaction_name,
+                            ..
+                        },
+                    ..
+                })) if reaction_name == *reaction => {
+                    current_span.set_attribute("slack.event.outcome", "queued");
+                    send_slack_push_event_callback_job(storage.as_ref(), event.clone()).await?;
+                }
+                Some(IntegrationConnectionConfig::Slack(SlackConfig {
+                    reaction_config:
+                        SlackReactionConfig {
+                            sync_enabled: false,
+                            ..
+                        },
+                    ..
+                })) => {
+                    current_span.set_attribute("slack.event.outcome", "discarded");
+                    current_span
+                        .set_attribute("slack.event.discard_reason", "reaction_sync_disabled");
+                }
+                Some(IntegrationConnectionConfig::Slack(_)) => {
+                    current_span.set_attribute("slack.event.outcome", "discarded");
+                    current_span
+                        .set_attribute("slack.event.discard_reason", "reaction_name_mismatch");
+                }
+                _ => {
+                    current_span.set_attribute("slack.event.outcome", "discarded");
+                    current_span.set_attribute("slack.event.discard_reason", "no_slack_config");
+                }
             }
         }
         SlackPushEvent::EventCallback(
             ref event @ SlackPushEventCallback {
                 event:
                     SlackEventCallbackBody::Message(SlackMessageEvent {
-                        origin: SlackMessageOrigin { ref thread_ts, .. },
+                        origin:
+                            SlackMessageOrigin {
+                                ref thread_ts,
+                                ref ts,
+                                ref channel,
+                                ..
+                            },
                         content: Some(ref content),
+                        sender: SlackMessageSender { ref user, .. },
                         ..
                     }),
                 ..
             },
         ) => {
-            //
+            current_span.set_attribute("slack.event_type", "message");
+            current_span.set_attribute("slack.team_id", event.team_id.to_string());
+            current_span.set_attribute("slack.event_id", event.event_id.to_string());
+            current_span.set_attribute("slack.ts", ts.to_string());
+            if let Some(thread_ts) = thread_ts {
+                current_span.set_attribute("slack.thread_ts", thread_ts.to_string());
+            }
+            if let Some(channel) = channel {
+                current_span.set_attribute("slack.channel_id", channel.to_string());
+            }
+            if let Some(user) = user {
+                current_span.set_attribute("slack.user_id", user.to_string());
+            }
+
             let service = third_party_item_service.read().await;
             let mut transaction = service.begin().await.context(
                 "Failed to create new transaction while checking for known Slack threads",
             )?;
 
             if has_slack_references_in_message(content) {
+                current_span.set_attribute("slack.event.outcome", "queued");
+                current_span.set_attribute("slack.event.queue_reason", "has_references");
                 send_slack_push_event_callback_job(storage.as_ref(), event.clone()).await?;
                 return Ok(HttpResponse::Ok().finish());
             }
@@ -127,15 +190,26 @@ pub async fn push_slack_event(
                     )
                     .await?
             {
+                current_span.set_attribute("slack.event.outcome", "queued");
+                current_span.set_attribute("slack.event.queue_reason", "known_thread");
                 send_slack_push_event_callback_job(storage.as_ref(), event.clone()).await?;
                 return Ok(HttpResponse::Ok().finish());
             }
+
+            current_span.set_attribute("slack.event.outcome", "discarded");
+            current_span.set_attribute(
+                "slack.event.discard_reason",
+                "no_references_no_known_thread",
+            );
         }
         SlackPushEvent::AppRateLimited(SlackAppRateLimitedEvent {
             team_id,
             minute_rate_limited,
             api_app_id,
         }) => {
+            current_span.set_attribute("slack.event_type", "app_rate_limited");
+            current_span.set_attribute("slack.team_id", team_id.to_string());
+            current_span.set_attribute("slack.event.outcome", "rate_limited");
             warn!(
                 ?team_id,
                 ?api_app_id,
@@ -149,6 +223,11 @@ pub async fn push_slack_event(
             event_id,
             ..
         }) => {
+            current_span.set_attribute("slack.event_type", "unknown");
+            current_span.set_attribute("slack.team_id", team_id.to_string());
+            current_span.set_attribute("slack.event_id", event_id.to_string());
+            current_span.set_attribute("slack.event.outcome", "discarded");
+            current_span.set_attribute("slack.event.discard_reason", "unknown_event_type");
             warn!(
                 ?team_id,
                 ?api_app_id,


### PR DESCRIPTION
## Summary

- Add OpenTelemetry span attributes at every decision point in the Slack event processing pipeline to diagnose missing notifications
- Instrument 8 functions across 5 files: webhook entry point, job dispatcher, reaction/message handlers, and item fetch layer
- Record `slack.event_type`, `slack.team_id`, `slack.event_id`, `slack.ts`, `slack.thread_ts`, `slack.channel_id`, outcome and discard reasons at every branch
- Refactor reaction config check in webhook handler into multi-arm match for distinct discard reasons (`reaction_sync_disabled`, `reaction_name_mismatch`, `no_slack_config`)

## Test plan

- [x] `just check` passes (clippy + compile)
- [x] All 36 `slack_webhook` tests pass (webhook, message, reaction)
- [ ] Deploy and inspect OTEL traces in Honeycomb for new span attributes on incoming Slack events

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/universal-inbox/universal-inbox/pull/151" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal tracing and monitoring across Slack integrations to improve system observability and debugging capabilities for event processing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->