### PR TITLE
feat: Sync Slack thread read/unsubscribed status during notification sync

### DIFF
--- a/api/src/integrations/slack.rs
+++ b/api/src/integrations/slack.rs
@@ -198,7 +198,7 @@ impl SlackService {
         &self,
         channel: &SlackChannelId,
         root_message: &SlackTs,
-        current_message: &SlackTs,
+        current_message: Option<&SlackTs>,
         user_id: UserId,
         slack_api_token: &SlackApiToken,
     ) -> Result<Vec1<SlackHistoryMessage>, UniversalInboxError> {
@@ -208,7 +208,7 @@ impl SlackService {
             slack_api_token,
             channel,
             root_message,
-            current_message,
+            current_message.cloned(),
         )
         .await?;
         if result.was_cached {
@@ -665,7 +665,13 @@ impl SlackService {
         current_span.set_attribute("slack.channel_id", channel_id.to_string());
         let root_ts = origin.thread_ts.as_ref().unwrap_or(&origin.ts);
         let messages = self
-            .fetch_thread(channel_id, root_ts, &origin.ts, user_id, &slack_api_token)
+            .fetch_thread(
+                channel_id,
+                root_ts,
+                Some(&origin.ts),
+                user_id,
+                &slack_api_token,
+            )
             .await?;
         let channel = self.fetch_channel(channel_id, &slack_api_token).await?;
         let team = self
@@ -911,7 +917,7 @@ async fn cached_fetch_message(
 #[io_cached(
     key = "String",
     // Use user_id to avoid leaking a message to an unauthorized user
-    convert = r#"{ format!("{}__{}__{}__{}__{}", slack_base_url, _user_id, channel, root_message, current_message) }"#,
+    convert = r#"{ format!("{}__{}__{}__{}__{:?}", slack_base_url, _user_id, channel, root_message, current_message) }"#,
     ty = "cached::AsyncRedisCache<String, Vec<SlackHistoryMessage>>",
     map_error = r##"|e| UniversalInboxError::Unexpected(anyhow!("Failed to cache Slack `fetch_thread`: {:?}", e))"##,
     create = r##" { build_redis_cache("slack:fetch_thread", Duration::from_secs(60), false).await }"##,
@@ -923,17 +929,19 @@ async fn cached_fetch_thread(
     slack_api_token: &SlackApiToken,
     channel: &SlackChannelId,
     root_message: &SlackTs,
-    current_message: &SlackTs,
+    current_message: Option<SlackTs>,
 ) -> Result<Return<Vec<SlackHistoryMessage>>, UniversalInboxError> {
     let client = SlackService::build_slack_client_from_url(slack_base_url)?;
     let session = client.open_session(slack_api_token);
 
+    let mut request =
+        SlackApiConversationsRepliesRequest::new(channel.clone(), root_message.clone());
+    if let Some(ref latest) = current_message {
+        request = request.with_latest(latest.clone()).with_inclusive(true);
+    }
+
     let messages = session
-        .conversations_replies(
-            &SlackApiConversationsRepliesRequest::new(channel.clone(), root_message.clone())
-                .with_latest(current_message.clone())
-                .with_inclusive(true),
-        )
+        .conversations_replies(&request)
         .await
         .with_context(|| {
             UniversalInboxError::Unexpected(anyhow!(
@@ -1209,13 +1217,7 @@ impl ThirdPartyItemSourceService<SlackThread> for SlackService {
                 .with_team_id(slack_thread.team.id.clone());
 
             let messages = match self
-                .fetch_thread(
-                    channel_id,
-                    root_ts,
-                    &slack_thread.messages.last().origin.ts,
-                    user_id,
-                    &slack_api_token,
-                )
+                .fetch_thread(channel_id, root_ts, None, user_id, &slack_api_token)
                 .await
             {
                 Ok(messages) => messages,

--- a/api/src/integrations/slack.rs
+++ b/api/src/integrations/slack.rs
@@ -12,7 +12,7 @@ use slack_morphism::{
 };
 use sqlx::{Postgres, Transaction};
 use tokio::sync::RwLock;
-use tracing::{debug, warn};
+use tracing::{debug, error, warn};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use url::Url;
 use uuid::Uuid;
@@ -32,7 +32,10 @@ use universal_inbox::{
             SlackMessageDetails, SlackMessageSenderDetails, SlackReaction, SlackReactionItem,
             SlackReactionState, SlackThread,
         },
-        item::{ThirdPartyItem, ThirdPartyItemData, ThirdPartyItemFromSource},
+        item::{
+            ThirdPartyItem, ThirdPartyItemData, ThirdPartyItemFromSource, ThirdPartyItemKind,
+            ThirdPartyItemSourceKind,
+        },
     },
     user::UserId,
     utils::{default_value::DefaultValue, truncate::truncate_with_ellipse},
@@ -41,7 +44,9 @@ use universal_inbox::{
 use crate::{
     integrations::{
         notification::ThirdPartyNotificationSourceService, task::ThirdPartyTaskService,
+        third_party::ThirdPartyItemSourceService,
     },
+    repository::{Repository, third_party::ThirdPartyItemRepository},
     universal_inbox::{
         UniversalInboxError, integration_connection::service::IntegrationConnectionService,
         slack_bridge::service::SlackBridgeService,
@@ -54,6 +59,7 @@ static SLACK_BASE_URL: &str = "https://api.slack.com/api";
 #[derive(Clone)]
 pub struct SlackService {
     slack_base_url: String,
+    repository: Arc<Repository>,
     integration_connection_service: Arc<RwLock<IntegrationConnectionService>>,
     slack_bridge_service: Arc<SlackBridgeService>,
 }
@@ -61,11 +67,13 @@ pub struct SlackService {
 impl SlackService {
     pub fn new(
         slack_base_url: Option<String>,
+        repository: Arc<Repository>,
         integration_connection_service: Arc<RwLock<IntegrationConnectionService>>,
         slack_bridge_service: Arc<SlackBridgeService>,
     ) -> Self {
         Self {
             slack_base_url: slack_base_url.unwrap_or_else(|| SLACK_BASE_URL.to_string()),
+            repository,
             integration_connection_service,
             slack_bridge_service,
         }
@@ -1146,6 +1154,142 @@ impl TaskSource for SlackService {
 impl IntegrationProviderSource for SlackService {
     fn get_integration_provider_kind(&self) -> IntegrationProviderKind {
         IntegrationProviderKind::Slack
+    }
+}
+
+#[async_trait]
+impl ThirdPartyItemSourceService<SlackThread> for SlackService {
+    #[tracing::instrument(
+        level = "debug",
+        skip_all,
+        fields(user.id = user_id.to_string()),
+        err
+    )]
+    async fn fetch_items(
+        &self,
+        executor: &mut Transaction<'_, Postgres>,
+        user_id: UserId,
+        _last_sync_completed_at: Option<DateTime<Utc>>,
+    ) -> Result<Vec<ThirdPartyItem>, UniversalInboxError> {
+        let (access_token, integration_connection) = self
+            .integration_connection_service
+            .read()
+            .await
+            .find_access_token(executor, IntegrationProviderKind::Slack, user_id)
+            .await?
+            .ok_or_else(|| {
+                anyhow!("Cannot sync Slack thread notifications without an access token")
+            })?;
+
+        let existing_items = self
+            .repository
+            .find_third_party_items_with_active_notification_for_user_id(
+                executor,
+                ThirdPartyItemKind::SlackThread,
+                NotificationStatus::Unread,
+                user_id,
+            )
+            .await?;
+
+        debug!(
+            "Found {} Slack threads with Unread notifications to sync for user {user_id}",
+            existing_items.len()
+        );
+
+        let mut updated_items = vec![];
+        for existing_item in existing_items {
+            let ThirdPartyItemData::SlackThread(ref slack_thread) = existing_item.data else {
+                continue;
+            };
+
+            let channel_id = &slack_thread.channel.id;
+            let root_ts = &slack_thread.messages.first().origin.ts;
+
+            let slack_api_token = SlackApiToken::new(SlackApiTokenValue(access_token.to_string()))
+                .with_team_id(slack_thread.team.id.clone());
+
+            let messages = match self
+                .fetch_thread(
+                    channel_id,
+                    root_ts,
+                    &slack_thread.messages.last().origin.ts,
+                    user_id,
+                    &slack_api_token,
+                )
+                .await
+            {
+                Ok(messages) => messages,
+                Err(err) => {
+                    error!(
+                        "Failed to fetch Slack thread {root_ts} in channel {channel_id} for user {user_id}: {err:?}"
+                    );
+                    continue;
+                }
+            };
+
+            let channel = self.fetch_channel(channel_id, &slack_api_token).await?;
+            let team = self
+                .fetch_team(&slack_thread.team.id, &slack_api_token)
+                .await?;
+            let sender_profiles = self
+                .fetch_sender_profiles_from_messages(&slack_api_token, &messages, user_id)
+                .await?;
+            let thread_params = &messages.first().parent;
+            let first_unread_message = SlackThread::first_unread_message_from_last_read(
+                &thread_params.last_read,
+                &messages,
+            );
+            let url = self
+                .get_chat_permalink(
+                    channel_id,
+                    &first_unread_message.origin.ts,
+                    &slack_api_token,
+                )
+                .await?;
+
+            let mut references = SlackReferences::new();
+            for message in messages.iter() {
+                if let Some(refs) = self
+                    .find_and_resolve_slack_references_in_message(
+                        &message.content,
+                        user_id,
+                        &slack_api_token,
+                    )
+                    .await
+                    .inspect_err(|err| {
+                        warn!("Failed to resolve Slack references in the message: {err:?}")
+                    })
+                    .unwrap_or(None)
+                {
+                    references.extend(refs);
+                }
+            }
+
+            let updated_thread = SlackThread {
+                url,
+                subscribed: thread_params.subscribed.unwrap_or(true),
+                last_read: thread_params.last_read.clone(),
+                sender_profiles,
+                messages,
+                channel,
+                team,
+                references: Some(references),
+                user_slack_id: integration_connection.provider_user_id.clone(),
+            };
+
+            updated_items
+                .push(updated_thread.into_third_party_item(user_id, integration_connection.id));
+        }
+
+        Ok(updated_items)
+    }
+
+    fn is_sync_incremental(&self) -> bool {
+        true
+    }
+
+    fn get_third_party_item_source_kind(&self) -> ThirdPartyItemSourceKind {
+        ThirdPartyItemSourceKind::SlackThread
     }
 }
 

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -614,6 +614,7 @@ pub async fn build_services(
     let slack_bridge_service = Arc::new(SlackBridgeService::new(repository.clone()));
     let slack_service = Arc::new(SlackService::new(
         slack_base_url,
+        repository.clone(),
         integration_connection_service.clone(),
         slack_bridge_service.clone(),
     ));

--- a/api/src/repository/third_party.rs
+++ b/api/src/repository/third_party.rs
@@ -6,6 +6,7 @@ use tracing::debug;
 use uuid::Uuid;
 
 use universal_inbox::{
+    notification::NotificationStatus,
     task::TaskSourceKind,
     third_party::item::{ThirdPartyItem, ThirdPartyItemData, ThirdPartyItemId, ThirdPartyItemKind},
     user::UserId,
@@ -53,6 +54,14 @@ pub trait ThirdPartyItemRepository {
         &self,
         executor: &mut Transaction<'_, Postgres>,
         kind: ThirdPartyItemKind,
+        user_id: UserId,
+    ) -> Result<Vec<ThirdPartyItem>, UniversalInboxError>;
+
+    async fn find_third_party_items_with_active_notification_for_user_id(
+        &self,
+        executor: &mut Transaction<'_, Postgres>,
+        kind: ThirdPartyItemKind,
+        notification_status: NotificationStatus,
         user_id: UserId,
     ) -> Result<Vec<ThirdPartyItem>, UniversalInboxError>;
 }
@@ -464,6 +473,66 @@ impl ThirdPartyItemRepository for Repository {
             .await
             .map_err(|err| {
                 let message = format!("Failed to find {kind} third party item for user_id {user_id} from storage: {err}");
+                UniversalInboxError::DatabaseError {
+                    source: err,
+                    message,
+                }
+            })?;
+
+        records
+            .iter()
+            .map(|r| r.try_into())
+            .collect::<Result<Vec<ThirdPartyItem>, UniversalInboxError>>()
+    }
+
+    #[tracing::instrument(
+        level = "debug",
+        skip_all,
+        fields(kind = kind.to_string(), notification_status = notification_status.to_string(), user.id = user_id.to_string()),
+        err
+    )]
+    async fn find_third_party_items_with_active_notification_for_user_id(
+        &self,
+        executor: &mut Transaction<'_, Postgres>,
+        kind: ThirdPartyItemKind,
+        notification_status: NotificationStatus,
+        user_id: UserId,
+    ) -> Result<Vec<ThirdPartyItem>, UniversalInboxError> {
+        let mut query_builder = QueryBuilder::new(
+            r#"
+              SELECT
+                third_party_item.id as third_party_item__id,
+                third_party_item.source_id as third_party_item__source_id,
+                third_party_item.data as third_party_item__data,
+                third_party_item.created_at as third_party_item__created_at,
+                third_party_item.updated_at as third_party_item__updated_at,
+                third_party_item.user_id as third_party_item__user_id,
+                third_party_item.integration_connection_id as third_party_item__integration_connection_id,
+                source_item.id as third_party_item__si__id,
+                source_item.source_id as third_party_item__si__source_id,
+                source_item.data as third_party_item__si__data,
+                source_item.created_at as third_party_item__si__created_at,
+                source_item.updated_at as third_party_item__si__updated_at,
+                source_item.user_id as third_party_item__si__user_id,
+                source_item.integration_connection_id as third_party_item__si__integration_connection_id
+              FROM third_party_item
+              LEFT JOIN third_party_item as source_item ON third_party_item.source_item_id = source_item.id
+              INNER JOIN notification ON notification.source_item_id = third_party_item.id
+            "#,
+        );
+        query_builder.push(" WHERE third_party_item.user_id = ");
+        query_builder.push_bind(user_id.0);
+        query_builder.push(" AND third_party_item.kind::TEXT = ");
+        query_builder.push_bind(kind.to_string());
+        query_builder.push(" AND notification.status::TEXT = ");
+        query_builder.push_bind(notification_status.to_string());
+
+        let records = query_builder
+            .build_query_as::<ThirdPartyItemRow>()
+            .fetch_all(&mut **executor)
+            .await
+            .map_err(|err| {
+                let message = format!("Failed to find {kind} third party items with {notification_status} notification for user_id {user_id} from storage: {err}");
                 UniversalInboxError::DatabaseError {
                     source: err,
                     message,

--- a/api/src/universal_inbox/notification/service.rs
+++ b/api/src/universal_inbox/notification/service.rs
@@ -635,6 +635,15 @@ impl NotificationService {
                 )
                 .await
             }
+            NotificationSyncSourceKind::Slack => {
+                self.sync_third_party_notifications(
+                    executor,
+                    self.slack_service.clone(),
+                    user_id,
+                    force_sync,
+                )
+                .await
+            }
         }
     }
 
@@ -710,12 +719,20 @@ impl NotificationService {
                 force_sync,
             )
             .await?;
+        let notifications_from_slack = self
+            .sync_notifications_with_transaction(
+                NotificationSyncSourceKind::Slack,
+                user_id,
+                force_sync,
+            )
+            .await?;
 
         Ok(notifications_from_github
             .into_iter()
             .chain(notifications_from_linear.into_iter())
             .chain(notifications_from_google_drive.into_iter())
             .chain(notifications_from_google_mail.into_iter())
+            .chain(notifications_from_slack.into_iter())
             .collect())
     }
 

--- a/api/tests/api/helpers/notification/slack.rs
+++ b/api/tests/api/helpers/notification/slack.rs
@@ -163,6 +163,44 @@ pub async fn mock_slack_fetch_thread(
         .await;
 }
 
+pub async fn mock_slack_fetch_full_thread(
+    slack_mock_server: &MockServer,
+    channel_id: &str,
+    first_message_id: &str,
+    fixture_response_file: &str,
+    subscribed: bool,
+    last_read_message_index: Option<usize>,
+    access_token: &str,
+) {
+    let mut json_body: Value = load_json_fixture_file(fixture_response_file);
+    json_body["messages"][0]["subscribed"] = Value::Bool(subscribed);
+    json_body["messages"][0]["last_read"] = match last_read_message_index {
+        Some(index) => Value::String(
+            json_body["messages"][index]["ts"]
+                .as_str()
+                .unwrap()
+                .to_string(),
+        ),
+        None => Value::Null,
+    };
+
+    Mock::given(method("GET"))
+        .and(header(
+            "authorization",
+            format!("Bearer {access_token}").as_str(),
+        ))
+        .and(path("/conversations.replies"))
+        .and(query_param("channel", channel_id))
+        .and(query_param("ts", first_message_id))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "application/json")
+                .set_body_json(json_body),
+        )
+        .mount(slack_mock_server)
+        .await;
+}
+
 pub async fn mock_slack_fetch_channel(
     slack_mock_server: &MockServer,
     channel_id: &str,

--- a/api/tests/api/main.rs
+++ b/api/tests/api/main.rs
@@ -26,6 +26,7 @@ mod test_sync_google_drive_comments;
 mod test_sync_google_mail_threads;
 mod test_sync_linear_notifications;
 mod test_sync_linear_tasks;
+mod test_sync_slack_threads;
 mod test_sync_todoist_tasks;
 mod test_tasks;
 mod test_todoist_notifications;

--- a/api/tests/api/test_sync_slack_threads.rs
+++ b/api/tests/api/test_sync_slack_threads.rs
@@ -16,9 +16,9 @@ use crate::helpers::{
     integration_connection::{create_and_mock_integration_connection, nango_slack_connection},
     notification::{
         slack::{
-            create_notification_from_slack_thread, mock_slack_fetch_channel, mock_slack_fetch_team,
-            mock_slack_fetch_thread, mock_slack_fetch_user, mock_slack_get_chat_permalink,
-            slack_thread,
+            create_notification_from_slack_thread, mock_slack_fetch_channel,
+            mock_slack_fetch_full_thread, mock_slack_fetch_team, mock_slack_fetch_user,
+            mock_slack_get_chat_permalink, slack_thread,
         },
         sync_notifications,
     },
@@ -68,11 +68,10 @@ mod sync_slack_thread_notifications {
 
         // Mock Slack API to return thread with last_read matching the last message
         // (i.e., user read all messages in Slack)
-        mock_slack_fetch_thread(
+        mock_slack_fetch_full_thread(
             &app.app.slack_mock_server,
             "C05XXX",
             &first_message_id,
-            &last_message_id,
             "slack_fetch_thread_response.json",
             true,
             Some(1), // last_read = last message index (message at index 1)
@@ -156,14 +155,12 @@ mod sync_slack_thread_notifications {
         assert_eq!(existing_notification.status, NotificationStatus::Unread);
 
         let first_message_id = slack_thread.messages.first().origin.ts.to_string();
-        let last_message_id = slack_thread.messages.last().origin.ts.to_string();
 
         // Mock Slack API to return thread with subscribed: false
-        mock_slack_fetch_thread(
+        mock_slack_fetch_full_thread(
             &app.app.slack_mock_server,
             "C05XXX",
             &first_message_id,
-            &last_message_id,
             "slack_fetch_thread_response.json",
             false, // subscribed = false (user unsubscribed in Slack)
             None,
@@ -250,14 +247,12 @@ mod sync_slack_thread_notifications {
         assert_eq!(existing_notification.status, NotificationStatus::Unread);
 
         let first_message_id = slack_thread.messages.first().origin.ts.to_string();
-        let last_message_id = slack_thread.messages.last().origin.ts.to_string();
 
         // Mock Slack API to return thread with same status (still unread)
-        mock_slack_fetch_thread(
+        mock_slack_fetch_full_thread(
             &app.app.slack_mock_server,
             "C05XXX",
             &first_message_id,
-            &last_message_id,
             "slack_fetch_thread_response.json",
             true,
             None, // No last_read => still unread

--- a/api/tests/api/test_sync_slack_threads.rs
+++ b/api/tests/api/test_sync_slack_threads.rs
@@ -1,0 +1,310 @@
+#![allow(clippy::too_many_arguments)]
+use rstest::*;
+
+use universal_inbox::{
+    integration_connection::{
+        config::IntegrationConnectionConfig, integrations::slack::SlackConfig,
+    },
+    notification::{NotificationSourceKind, NotificationStatus},
+    third_party::integrations::slack::SlackThread,
+};
+
+use universal_inbox_api::{configuration::Settings, integrations::oauth2::NangoConnection};
+
+use crate::helpers::{
+    auth::{AuthenticatedApp, authenticated_app},
+    integration_connection::{create_and_mock_integration_connection, nango_slack_connection},
+    notification::{
+        slack::{
+            create_notification_from_slack_thread, mock_slack_fetch_channel, mock_slack_fetch_team,
+            mock_slack_fetch_thread, mock_slack_fetch_user, mock_slack_get_chat_permalink,
+            slack_thread,
+        },
+        sync_notifications,
+    },
+    settings,
+};
+
+mod sync_slack_thread_notifications {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_sync_slack_thread_marked_as_read(
+        settings: Settings,
+        #[future] authenticated_app: AuthenticatedApp,
+        nango_slack_connection: Box<NangoConnection>,
+        slack_thread: Box<SlackThread>,
+    ) {
+        let app = authenticated_app.await;
+        let slack_integration_connection = create_and_mock_integration_connection(
+            &app.app,
+            app.user.id,
+            &settings.oauth2.nango_secret_key,
+            IntegrationConnectionConfig::Slack(SlackConfig::enabled_as_notifications()),
+            &settings,
+            nango_slack_connection,
+            None,
+            None,
+        )
+        .await;
+
+        // Create a notification from a slack thread (will be Unread because
+        // last_read is set to the first message, not the last)
+        let mut unread_slack_thread = *slack_thread.clone();
+        unread_slack_thread.last_read = None;
+        let existing_notification = create_notification_from_slack_thread(
+            &app.app,
+            &unread_slack_thread,
+            app.user.id,
+            slack_integration_connection.id,
+        )
+        .await;
+        assert_eq!(existing_notification.status, NotificationStatus::Unread);
+
+        let first_message_id = slack_thread.messages.first().origin.ts.to_string();
+        let last_message_id = slack_thread.messages.last().origin.ts.to_string();
+
+        // Mock Slack API to return thread with last_read matching the last message
+        // (i.e., user read all messages in Slack)
+        mock_slack_fetch_thread(
+            &app.app.slack_mock_server,
+            "C05XXX",
+            &first_message_id,
+            &last_message_id,
+            "slack_fetch_thread_response.json",
+            true,
+            Some(1), // last_read = last message index (message at index 1)
+            "slack_test_user_access_token",
+        )
+        .await;
+        mock_slack_fetch_channel(
+            &app.app.slack_mock_server,
+            "C05XXX",
+            "slack_fetch_channel_response.json",
+        )
+        .await;
+        mock_slack_fetch_team(
+            &app.app.slack_mock_server,
+            "T05XXX",
+            "slack_fetch_team_response.json",
+        )
+        .await;
+        mock_slack_fetch_user(
+            &app.app.slack_mock_server,
+            "U01",
+            "slack_fetch_user_response.json",
+        )
+        .await;
+        mock_slack_fetch_user(
+            &app.app.slack_mock_server,
+            "U02",
+            "slack_fetch_user_response.json",
+        )
+        .await;
+        mock_slack_get_chat_permalink(
+            &app.app.slack_mock_server,
+            "C05XXX",
+            &last_message_id,
+            "slack_get_chat_permalink_response.json",
+        )
+        .await;
+
+        let synced_notifications = sync_notifications(
+            &app.client,
+            &app.app.api_address,
+            Some(NotificationSourceKind::Slack),
+            false,
+        )
+        .await;
+
+        assert_eq!(synced_notifications.len(), 1);
+        assert_eq!(synced_notifications[0].status, NotificationStatus::Deleted);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_sync_slack_thread_marked_as_unsubscribed(
+        settings: Settings,
+        #[future] authenticated_app: AuthenticatedApp,
+        nango_slack_connection: Box<NangoConnection>,
+        slack_thread: Box<SlackThread>,
+    ) {
+        let app = authenticated_app.await;
+        let slack_integration_connection = create_and_mock_integration_connection(
+            &app.app,
+            app.user.id,
+            &settings.oauth2.nango_secret_key,
+            IntegrationConnectionConfig::Slack(SlackConfig::enabled_as_notifications()),
+            &settings,
+            nango_slack_connection,
+            None,
+            None,
+        )
+        .await;
+
+        let mut unread_slack_thread = *slack_thread.clone();
+        unread_slack_thread.last_read = None;
+        let existing_notification = create_notification_from_slack_thread(
+            &app.app,
+            &unread_slack_thread,
+            app.user.id,
+            slack_integration_connection.id,
+        )
+        .await;
+        assert_eq!(existing_notification.status, NotificationStatus::Unread);
+
+        let first_message_id = slack_thread.messages.first().origin.ts.to_string();
+        let last_message_id = slack_thread.messages.last().origin.ts.to_string();
+
+        // Mock Slack API to return thread with subscribed: false
+        mock_slack_fetch_thread(
+            &app.app.slack_mock_server,
+            "C05XXX",
+            &first_message_id,
+            &last_message_id,
+            "slack_fetch_thread_response.json",
+            false, // subscribed = false (user unsubscribed in Slack)
+            None,
+            "slack_test_user_access_token",
+        )
+        .await;
+        mock_slack_fetch_channel(
+            &app.app.slack_mock_server,
+            "C05XXX",
+            "slack_fetch_channel_response.json",
+        )
+        .await;
+        mock_slack_fetch_team(
+            &app.app.slack_mock_server,
+            "T05XXX",
+            "slack_fetch_team_response.json",
+        )
+        .await;
+        mock_slack_fetch_user(
+            &app.app.slack_mock_server,
+            "U01",
+            "slack_fetch_user_response.json",
+        )
+        .await;
+        mock_slack_fetch_user(
+            &app.app.slack_mock_server,
+            "U02",
+            "slack_fetch_user_response.json",
+        )
+        .await;
+        mock_slack_get_chat_permalink(
+            &app.app.slack_mock_server,
+            "C05XXX",
+            &first_message_id,
+            "slack_get_chat_permalink_response.json",
+        )
+        .await;
+
+        let synced_notifications = sync_notifications(
+            &app.client,
+            &app.app.api_address,
+            Some(NotificationSourceKind::Slack),
+            false,
+        )
+        .await;
+
+        assert_eq!(synced_notifications.len(), 1);
+        assert_eq!(
+            synced_notifications[0].status,
+            NotificationStatus::Unsubscribed
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_sync_slack_thread_no_change(
+        settings: Settings,
+        #[future] authenticated_app: AuthenticatedApp,
+        nango_slack_connection: Box<NangoConnection>,
+        slack_thread: Box<SlackThread>,
+    ) {
+        let app = authenticated_app.await;
+        let slack_integration_connection = create_and_mock_integration_connection(
+            &app.app,
+            app.user.id,
+            &settings.oauth2.nango_secret_key,
+            IntegrationConnectionConfig::Slack(SlackConfig::enabled_as_notifications()),
+            &settings,
+            nango_slack_connection,
+            None,
+            None,
+        )
+        .await;
+
+        let mut unread_slack_thread = *slack_thread.clone();
+        unread_slack_thread.last_read = None;
+        let existing_notification = create_notification_from_slack_thread(
+            &app.app,
+            &unread_slack_thread,
+            app.user.id,
+            slack_integration_connection.id,
+        )
+        .await;
+        assert_eq!(existing_notification.status, NotificationStatus::Unread);
+
+        let first_message_id = slack_thread.messages.first().origin.ts.to_string();
+        let last_message_id = slack_thread.messages.last().origin.ts.to_string();
+
+        // Mock Slack API to return thread with same status (still unread)
+        mock_slack_fetch_thread(
+            &app.app.slack_mock_server,
+            "C05XXX",
+            &first_message_id,
+            &last_message_id,
+            "slack_fetch_thread_response.json",
+            true,
+            None, // No last_read => still unread
+            "slack_test_user_access_token",
+        )
+        .await;
+        mock_slack_fetch_channel(
+            &app.app.slack_mock_server,
+            "C05XXX",
+            "slack_fetch_channel_response.json",
+        )
+        .await;
+        mock_slack_fetch_team(
+            &app.app.slack_mock_server,
+            "T05XXX",
+            "slack_fetch_team_response.json",
+        )
+        .await;
+        mock_slack_fetch_user(
+            &app.app.slack_mock_server,
+            "U01",
+            "slack_fetch_user_response.json",
+        )
+        .await;
+        mock_slack_fetch_user(
+            &app.app.slack_mock_server,
+            "U02",
+            "slack_fetch_user_response.json",
+        )
+        .await;
+        mock_slack_get_chat_permalink(
+            &app.app.slack_mock_server,
+            "C05XXX",
+            &first_message_id,
+            "slack_get_chat_permalink_response.json",
+        )
+        .await;
+
+        let synced_notifications = sync_notifications(
+            &app.client,
+            &app.app.api_address,
+            Some(NotificationSourceKind::Slack),
+            false,
+        )
+        .await;
+
+        assert_eq!(synced_notifications.len(), 1);
+        assert_eq!(synced_notifications[0].status, NotificationStatus::Unread);
+    }
+}

--- a/src/integration_connection/provider.rs
+++ b/src/integration_connection/provider.rs
@@ -192,7 +192,7 @@ impl IntegrationProvider {
             IntegrationProvider::Linear { config } => config.sync_notifications_enabled,
             IntegrationProvider::GoogleDrive { config, .. } => config.sync_notifications_enabled,
             IntegrationProvider::GoogleMail { config, .. } => config.sync_notifications_enabled,
-            IntegrationProvider::Slack { .. } => false, // Slack notifications are not synced but received via the webhook
+            IntegrationProvider::Slack { config, .. } => config.message_config.sync_enabled,
             _ => false,
         }
     }

--- a/src/notification/mod.rs
+++ b/src/notification/mod.rs
@@ -235,7 +235,8 @@ macro_attr! {
         Github,
         Linear,
         GoogleMail,
-        GoogleDrive
+        GoogleDrive,
+        Slack
     }
 }
 
@@ -265,7 +266,9 @@ impl TryFrom<ThirdPartyItemSourceKind> for NotificationSourceKind {
             ThirdPartyItemSourceKind::LinearNotification => Ok(Self::Linear),
             ThirdPartyItemSourceKind::GoogleMailThread => Ok(Self::GoogleMail),
             ThirdPartyItemSourceKind::GoogleDriveComment => Ok(Self::GoogleDrive),
-            ThirdPartyItemSourceKind::SlackReaction => Ok(Self::Slack),
+            ThirdPartyItemSourceKind::SlackReaction | ThirdPartyItemSourceKind::SlackThread => {
+                Ok(Self::Slack)
+            }
             ThirdPartyItemSourceKind::WebPage => Ok(Self::API),
             _ => Err(anyhow!(
                 "ThirdPartyItemSourceKind {source_kind} is not a valid NotificationSourceKind"
@@ -284,6 +287,7 @@ impl TryFrom<IntegrationProviderKind> for NotificationSyncSourceKind {
             IntegrationProviderKind::Linear => Ok(Self::Linear),
             IntegrationProviderKind::GoogleMail => Ok(Self::GoogleMail),
             IntegrationProviderKind::GoogleDrive => Ok(Self::GoogleDrive),
+            IntegrationProviderKind::Slack => Ok(Self::Slack),
             _ => Err(anyhow!(
                 "IntegrationProviderKind {provider_kind} is not a valid NotificationSyncSourceKind"
             )),
@@ -299,6 +303,7 @@ impl From<NotificationSyncSourceKind> for IntegrationProviderKind {
             NotificationSyncSourceKind::Linear => IntegrationProviderKind::Linear,
             NotificationSyncSourceKind::GoogleMail => IntegrationProviderKind::GoogleMail,
             NotificationSyncSourceKind::GoogleDrive => IntegrationProviderKind::GoogleDrive,
+            NotificationSyncSourceKind::Slack => IntegrationProviderKind::Slack,
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds Slack to the regular notification sync infrastructure so tracked threads are re-checked for read/unsubscribed status changes made from Slack apps
- Implements `ThirdPartyItemSourceService<SlackThread>` on `SlackService` — re-fetches threads with Unread notifications via `conversations.replies` to detect updated `subscribed`/`last_read` fields
- Only syncs threads that have Unread notifications (incremental sync, rate-limit friendly)

## Changes
- **Domain model**: Added `Slack` to `NotificationSyncSourceKind`, fixed `SlackThread` → `NotificationSourceKind` conversion
- **Config**: `is_sync_notifications_enabled()` for Slack now uses `message_config.sync_enabled`
- **Repository**: New `find_third_party_items_with_active_notification_for_user_id()` query (JOIN with notification table)
- **SlackService**: Added `repository` field, implemented `ThirdPartyItemSourceService<SlackThread>`
- **NotificationService**: Wired Slack into `sync_notifications()` and `sync_all_notifications()`

## Test plan
- [x] 3 new integration tests: thread marked as read, thread unsubscribed, no change
- [x] Existing Slack notification tests pass (3/3)
- [x] Existing Slack webhook message tests pass (26/26)
- [x] Existing GitHub sync tests pass (9/9)
- [x] `just check` passes in both root and API crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/universal-inbox/universal-inbox/pull/152" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unread Slack threads now sync as notifications and are treated as a Slack notification source.
  * Notification status updates automatically when threads are read or when subscription state changes.
  * Slack notification syncing can be enabled per integration connection.

* **Tests**
  * Added integration tests covering Slack thread synchronization and notification state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->