### PR TITLE
feat: Add searchable emoji picker for Slack reactions

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Devbox
-        uses: jetpack-io/devbox-install-action@v0.12.0
+        uses: jetify-com/devbox-install-action@v0.15.0
         with:
           enable-cache: "true"
 
@@ -44,7 +44,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Devbox
-        uses: jetpack-io/devbox-install-action@v0.12.0
+        uses: jetify-com/devbox-install-action@v0.15.0
         with:
           enable-cache: "true"
       - name: Check formatting
@@ -58,7 +58,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Devbox
-        uses: jetpack-io/devbox-install-action@v0.12.0
+        uses: jetify-com/devbox-install-action@v0.15.0
         with:
           enable-cache: "true"
       - name: Check formatting
@@ -72,7 +72,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Devbox
-        uses: jetpack-io/devbox-install-action@v0.12.0
+        uses: jetify-com/devbox-install-action@v0.15.0
         with:
           enable-cache: "true"
       - uses: Swatinem/rust-cache@v2
@@ -89,7 +89,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Devbox
-        uses: jetpack-io/devbox-install-action@v0.12.0
+        uses: jetify-com/devbox-install-action@v0.15.0
         with:
           enable-cache: "true"
       - uses: Swatinem/rust-cache@v2
@@ -122,7 +122,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Devbox
-        uses: jetpack-io/devbox-install-action@v0.12.0
+        uses: jetify-com/devbox-install-action@v0.15.0
         with:
           enable-cache: "true"
       - uses: Swatinem/rust-cache@v2
@@ -172,7 +172,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Devbox
-        uses: jetpack-io/devbox-install-action@v0.12.0
+        uses: jetify-com/devbox-install-action@v0.15.0
         with:
           enable-cache: "true"
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Devbox
-        uses: jetpack-io/devbox-install-action@v0.12.0
+        uses: jetify-com/devbox-install-action@v0.15.0
         with:
           enable-cache: "true"
 
@@ -41,7 +41,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Devbox
-        uses: jetpack-io/devbox-install-action@v0.12.0
+        uses: jetify-com/devbox-install-action@v0.15.0
         with:
           enable-cache: "true"
       - name: Check formatting
@@ -55,7 +55,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Devbox
-        uses: jetpack-io/devbox-install-action@v0.12.0
+        uses: jetify-com/devbox-install-action@v0.15.0
         with:
           enable-cache: "true"
       - name: Check formatting
@@ -69,7 +69,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Devbox
-        uses: jetpack-io/devbox-install-action@v0.12.0
+        uses: jetify-com/devbox-install-action@v0.15.0
         with:
           enable-cache: "true"
       - uses: Swatinem/rust-cache@v2
@@ -86,7 +86,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Devbox
-        uses: jetpack-io/devbox-install-action@v0.12.0
+        uses: jetify-com/devbox-install-action@v0.15.0
         with:
           enable-cache: "true"
       - uses: Swatinem/rust-cache@v2
@@ -112,7 +112,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Devbox
-        uses: jetpack-io/devbox-install-action@v0.12.0
+        uses: jetify-com/devbox-install-action@v0.15.0
         with:
           enable-cache: "true"
       - uses: Swatinem/rust-cache@v2
@@ -162,7 +162,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Devbox
-        uses: jetpack-io/devbox-install-action@v0.12.0
+        uses: jetify-com/devbox-install-action@v0.15.0
         with:
           enable-cache: "true"
       - uses: Swatinem/rust-cache@v2
@@ -220,7 +220,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Devbox
-        uses: jetpack-io/devbox-install-action@v0.12.0
+        uses: jetify-com/devbox-install-action@v0.15.0
         with:
           enable-cache: "true"
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Devbox
-        uses: jetpack-io/devbox-install-action@v0.7.0
+        uses: jetify-com/devbox-install-action@v0.15.0
         with:
           enable-cache: "true"
       - name: Build documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@
 - Replace `typed_id` + `paste` crates with inline implementation to resolve RUSTSEC-2024-0436 (unmaintained `paste` crate)
 - Downgrade `zip` from yanked 7.4.0 to 7.2.0 (resolves GH#133)
 
+### Fixed
+
+- Scope the `slack:list_emojis` Redis cache entry by workspace team id so custom emojis from one workspace are no longer served to users of other workspaces
+
 ## 2026-03-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- Custom Slack reaction emoji picker in integration settings
+  - Replaces the hardcoded 5-emoji dropdown with a searchable selector
+  - Searches standard Unicode emojis first, then workspace custom emojis to fill up to the result limit
+  - New endpoint `GET /integration-connections/{id}/slack/emojis/search?matches=…` scoped to a specific connection so multiple Slack connections per user remain supported
+  - Graceful degradation: if the workspace emoji list cannot be fetched, the search still returns matching standard emojis
 - Add Slack browser-extension bridge for 2-way sync (delete/unsubscribe actions)
   - Extension polls for queued actions and executes them through Slack's private API using the user's authenticated browser session
   - Credential validation: extension sends live `team_id` + `user_id` pairs matched against the integration connection

--- a/api/src/integrations/slack.rs
+++ b/api/src/integrations/slack.rs
@@ -1203,7 +1203,7 @@ async fn cached_fetch_team(
 
 #[io_cached(
     key = "String",
-    convert = r#"{ format!("{}", slack_base_url) }"#,
+    convert = r#"{ format!("{}__{}", slack_base_url, slack_api_token.team_id.as_ref().map(|t| t.0.as_str()).unwrap_or("no-team")) }"#,
     ty = "cached::AsyncRedisCache<String, HashMap<SlackEmojiName, SlackEmojiRef>>",
     map_error = r##"|e| UniversalInboxError::Unexpected(anyhow!("Failed to cache Slack `list_emojis`: {:?}", e))"##,
     create = r##" { build_redis_cache("slack:list_emojis", Duration::from_secs(24 * 60 * 60), false).await }"##,

--- a/api/src/integrations/slack.rs
+++ b/api/src/integrations/slack.rs
@@ -17,11 +17,18 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 use url::Url;
 use uuid::Uuid;
 use vec1::Vec1;
-use wiremock::MockServer;
+use wiremock::{
+    Mock, MockServer, ResponseTemplate,
+    matchers::{method, path},
+};
 
 use universal_inbox::{
     HasHtmlUrl,
-    integration_connection::provider::{IntegrationProviderKind, IntegrationProviderSource},
+    integration_connection::{
+        IntegrationConnectionId,
+        integrations::slack::SlackEmojiSuggestion,
+        provider::{IntegrationProvider, IntegrationProviderKind, IntegrationProviderSource},
+    },
     notification::{Notification, NotificationSource, NotificationSourceKind, NotificationStatus},
     task::{
         CreateOrUpdateTaskRequest, TaskCreationConfig, TaskSource, TaskSourceKind, TaskStatus,
@@ -38,7 +45,10 @@ use universal_inbox::{
         },
     },
     user::UserId,
-    utils::{default_value::DefaultValue, truncate::truncate_with_ellipse},
+    utils::{
+        default_value::DefaultValue, emoji::search_emojis_by_shortcode,
+        truncate::truncate_with_ellipse,
+    },
 };
 
 use crate::{
@@ -79,7 +89,16 @@ impl SlackService {
         }
     }
 
-    pub async fn mock_all(_mock_server: &MockServer) {}
+    pub async fn mock_all(mock_server: &MockServer) {
+        Mock::given(method("GET"))
+            .and(path("/emoji.list"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "emoji": {},
+            })))
+            .mount(mock_server)
+            .await;
+    }
 
     async fn create_bridge_pending_action_if_enabled(
         &self,
@@ -342,6 +361,88 @@ impl SlackService {
             debug!("`list_emojis` cache hit");
         }
         Ok(result.value)
+    }
+
+    #[tracing::instrument(level = "debug", skip_all, fields(user.id = %user_id, integration_connection.id = %integration_connection_id, query))]
+    pub async fn search_emojis(
+        &self,
+        executor: &mut Transaction<'_, Postgres>,
+        integration_connection_id: IntegrationConnectionId,
+        user_id: UserId,
+        query: &str,
+        limit: usize,
+    ) -> Result<Vec<SlackEmojiSuggestion>, UniversalInboxError> {
+        // Search standard Unicode emojis first
+        let mut results: Vec<SlackEmojiSuggestion> = search_emojis_by_shortcode(query, limit)
+            .into_iter()
+            .map(|(shortcode, emoji_char)| SlackEmojiSuggestion {
+                display_name: format!("{emoji_char} :{shortcode}:"),
+                name: shortcode,
+            })
+            .collect();
+
+        // Only fetch custom emojis if we still have room under the limit
+        if results.len() < limit {
+            let workspace_emojis = match self
+                .list_workspace_emojis(executor, integration_connection_id, user_id)
+                .await
+            {
+                Ok(emojis) => emojis,
+                Err(err) => {
+                    warn!(
+                        "Failed to fetch Slack workspace emojis, falling back to standard emojis only: {err:?}"
+                    );
+                    HashMap::new()
+                }
+            };
+            let query_lower = query.to_lowercase();
+            for emoji_name in workspace_emojis.keys() {
+                if results.len() >= limit {
+                    break;
+                }
+                if emoji_name.0.to_lowercase().contains(&query_lower) {
+                    results.push(SlackEmojiSuggestion {
+                        name: emoji_name.0.clone(),
+                        display_name: format!(":{}: (custom)", emoji_name.0),
+                    });
+                }
+            }
+        }
+
+        Ok(results)
+    }
+
+    async fn list_workspace_emojis(
+        &self,
+        executor: &mut Transaction<'_, Postgres>,
+        integration_connection_id: IntegrationConnectionId,
+        user_id: UserId,
+    ) -> Result<HashMap<SlackEmojiName, SlackEmojiRef>, UniversalInboxError> {
+        let integration_connection_service = self.integration_connection_service.read().await;
+        let (access_token, integration_connection) = integration_connection_service
+            .find_access_token_for_connection(executor, integration_connection_id, user_id)
+            .await?
+            .ok_or_else(|| {
+                anyhow!(
+                    "No access token found for integration connection {integration_connection_id}"
+                )
+            })?;
+
+        let IntegrationProvider::Slack { context, .. } = &integration_connection.provider else {
+            return Err(UniversalInboxError::InvalidInputData {
+                source: None,
+                user_error: format!(
+                    "Integration connection {integration_connection_id} is not a Slack connection"
+                ),
+            });
+        };
+
+        let mut slack_api_token = SlackApiToken::new(SlackApiTokenValue(access_token.to_string()));
+        if let Some(ctx) = context.as_ref() {
+            slack_api_token = slack_api_token.with_team_id(ctx.team_id.clone());
+        }
+
+        self.list_emojis(&slack_api_token).await
     }
 
     pub async fn reactions_add(

--- a/api/src/routes/integration_connection.rs
+++ b/api/src/routes/integration_connection.rs
@@ -2,8 +2,11 @@ use std::sync::Arc;
 
 use actix_http::body::BoxBody;
 use actix_jwt_authc::Authenticated;
-use actix_web::{HttpResponse, Scope, web};
+use actix_web::{
+    HttpResponse, Scope, http::header::CacheControl, http::header::CacheDirective, web,
+};
 use anyhow::Context;
+use serde::Deserialize;
 use serde_json::json;
 use tokio::sync::RwLock;
 
@@ -19,6 +22,7 @@ use crate::{
     universal_inbox::{
         UniversalInboxError, UpdateStatus,
         integration_connection::service::IntegrationConnectionService,
+        notification::service::NotificationService,
     },
     utils::jwt::Claims,
 };
@@ -30,6 +34,10 @@ pub fn scope() -> Scope {
                 .name("integration-connections")
                 .route(web::get().to(list_integration_connections))
                 .route(web::post().to(create_integration_connection)),
+        )
+        .service(
+            web::scope("/{integration_connection_id}/slack")
+                .route("/emojis/search", web::get().to(search_slack_emojis)),
         )
         .service(
             web::resource("/{integration_connection_id}")
@@ -258,4 +266,66 @@ pub async fn disconnect_integration_connection(
                 .to_string(),
             ))),
     }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SearchSlackEmojiRequest {
+    matches: Option<String>,
+}
+
+pub async fn search_slack_emojis(
+    path: web::Path<IntegrationConnectionId>,
+    query: web::Query<SearchSlackEmojiRequest>,
+    notification_service: web::Data<Arc<RwLock<NotificationService>>>,
+    authenticated: Authenticated<Claims>,
+) -> Result<HttpResponse, UniversalInboxError> {
+    let user_id = authenticated
+        .claims
+        .sub
+        .parse::<UserId>()
+        .context("Wrong user ID format")?;
+    let integration_connection_id = path.into_inner();
+
+    let Some(matches) = &query.matches else {
+        return Ok(HttpResponse::Ok()
+            .content_type("application/json")
+            .insert_header(CacheControl(vec![
+                CacheDirective::Private,
+                CacheDirective::MaxAge(10u32),
+            ]))
+            .body("[]"));
+    };
+
+    let notification_service = notification_service.read().await;
+    let mut transaction = notification_service
+        .begin()
+        .await
+        .context("Failed to create transaction for Slack emoji search")?;
+
+    let results = notification_service
+        .slack_service
+        .search_emojis(
+            &mut transaction,
+            integration_connection_id,
+            user_id,
+            matches,
+            50,
+        )
+        .await?;
+
+    transaction
+        .commit()
+        .await
+        .context("Failed to commit transaction for Slack emoji search")?;
+
+    Ok(HttpResponse::Ok()
+        .content_type("application/json")
+        .insert_header(CacheControl(vec![
+            CacheDirective::Private,
+            CacheDirective::MaxAge(10u32),
+        ]))
+        .body(
+            serde_json::to_string(&results)
+                .context("Cannot serialize Slack emoji search results")?,
+        ))
 }

--- a/api/src/universal_inbox/integration_connection/service.rs
+++ b/api/src/universal_inbox/integration_connection/service.rs
@@ -756,6 +756,59 @@ impl IntegrationConnectionService {
             return Ok(None);
         };
 
+        self.fetch_access_token_for_integration_connection(
+            executor,
+            integration_connection,
+            for_user_id,
+        )
+        .await
+    }
+
+    #[tracing::instrument(
+        level = "debug",
+        skip_all,
+        fields(
+            integration_connection.id = integration_connection_id.to_string(),
+            user.id = for_user_id.to_string()
+        ),
+        err
+    )]
+    pub async fn find_access_token_for_connection(
+        &self,
+        executor: &mut Transaction<'_, Postgres>,
+        integration_connection_id: IntegrationConnectionId,
+        for_user_id: UserId,
+    ) -> Result<Option<(AccessToken, IntegrationConnection)>, UniversalInboxError> {
+        let integration_connection = self
+            .repository
+            .get_integration_connection(executor, integration_connection_id)
+            .await?;
+
+        let Some(integration_connection) = integration_connection else {
+            return Ok(None);
+        };
+
+        if integration_connection.user_id != for_user_id {
+            return Err(UniversalInboxError::Forbidden(format!(
+                "Integration connection {integration_connection_id} does not belong to user {for_user_id}"
+            )));
+        }
+
+        self.fetch_access_token_for_integration_connection(
+            executor,
+            integration_connection,
+            for_user_id,
+        )
+        .await
+    }
+
+    async fn fetch_access_token_for_integration_connection(
+        &self,
+        executor: &mut Transaction<'_, Postgres>,
+        integration_connection: IntegrationConnection,
+        for_user_id: UserId,
+    ) -> Result<Option<(AccessToken, IntegrationConnection)>, UniversalInboxError> {
+        let integration_provider_kind = integration_connection.provider.kind();
         if self
             .oauth2_providers
             .contains_key(&integration_provider_kind)

--- a/api/src/universal_inbox/integration_connection/service.rs
+++ b/api/src/universal_inbox/integration_connection/service.rs
@@ -794,6 +794,10 @@ impl IntegrationConnectionService {
             )));
         }
 
+        if integration_connection.status != IntegrationConnectionStatus::Validated {
+            return Ok(None);
+        }
+
         self.fetch_access_token_for_integration_connection(
             executor,
             integration_connection,

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -10,6 +10,9 @@ processes:
         condition: process_started
     availability:
       restart: no
+    shutdown:
+      signal: 9
+      timeout_seconds: 1
     disabled: true
     namespace: "universal-inbox"
 

--- a/src/integration_connection/integrations/slack.rs
+++ b/src/integration_connection/integrations/slack.rs
@@ -1,8 +1,22 @@
+use std::fmt;
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use slack_morphism::{SlackReactionName, SlackTeamId};
 
 use crate::task::{PresetDueDate, ProjectSummary, TaskPriority};
+
+#[derive(Deserialize, Serialize, PartialEq, Eq, Debug, Clone)]
+pub struct SlackEmojiSuggestion {
+    pub name: String,
+    pub display_name: String,
+}
+
+impl fmt::Display for SlackEmojiSuggestion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.display_name)
+    }
+}
 
 #[derive(Deserialize, Serialize, PartialEq, Eq, Debug, Clone)]
 pub struct SlackConfig {

--- a/src/utils/emoji.rs
+++ b/src/utils/emoji.rs
@@ -1,3 +1,28 @@
+pub fn search_emojis_by_shortcode(query: &str, limit: usize) -> Vec<(String, String)> {
+    let query_lower = query.to_lowercase();
+
+    let mut starts_with = Vec::new();
+    let mut contains = Vec::new();
+
+    for emoji in emojis::iter() {
+        for shortcode in emoji.shortcodes() {
+            let sc_lower = shortcode.to_lowercase();
+            if sc_lower.starts_with(&query_lower) {
+                starts_with.push((shortcode.to_string(), emoji.to_string()));
+            } else if sc_lower.contains(&query_lower) {
+                contains.push((shortcode.to_string(), emoji.to_string()));
+            }
+            if starts_with.len() + contains.len() >= limit * 2 {
+                break;
+            }
+        }
+    }
+
+    starts_with.extend(contains);
+    starts_with.truncate(limit);
+    starts_with
+}
+
 pub fn replace_emoji_code_in_string_with_emoji(string: &str) -> String {
     let mut result = String::new();
     let mut chars = string.chars();
@@ -119,6 +144,59 @@ mod tests {
                 replace_emoji_code_with_emoji(":RoCkEt:"),
                 Some("🚀".to_string())
             );
+        }
+    }
+
+    mod search_emojis_by_shortcode_tests {
+        use super::super::*;
+        use rstest::*;
+
+        #[rstest]
+        fn test_search_starts_with_match() {
+            let results = search_emojis_by_shortcode("rock", 10);
+            assert!(!results.is_empty());
+            assert!(results.iter().any(|(sc, _)| sc == "rocket"));
+        }
+
+        #[rstest]
+        fn test_search_case_insensitive() {
+            let results = search_emojis_by_shortcode("ROCK", 10);
+            assert!(results.iter().any(|(sc, _)| sc == "rocket"));
+        }
+
+        #[rstest]
+        fn test_search_contains_match() {
+            let results = search_emojis_by_shortcode("ocket", 10);
+            assert!(results.iter().any(|(sc, _)| sc == "rocket"));
+        }
+
+        #[rstest]
+        fn test_search_prioritizes_starts_with() {
+            let results = search_emojis_by_shortcode("eye", 50);
+            // "eyes" starts with "eye" so it should appear before any contains-only matches
+            if let Some(pos) = results.iter().position(|(sc, _)| sc == "eyes") {
+                // All items before "eyes" should also start with "eye"
+                for (sc, _) in &results[..pos] {
+                    assert!(
+                        sc.to_lowercase().starts_with("eye"),
+                        "{sc} should start with 'eye'"
+                    );
+                }
+            }
+        }
+
+        #[rstest]
+        fn test_search_respects_limit() {
+            let results = search_emojis_by_shortcode("a", 5);
+            assert!(results.len() <= 5);
+        }
+
+        #[rstest]
+        fn test_search_returns_emoji_chars() {
+            let results = search_emojis_by_shortcode("rocket", 5);
+            let rocket = results.iter().find(|(sc, _)| sc == "rocket");
+            assert!(rocket.is_some());
+            assert_eq!(rocket.unwrap().1, "🚀");
         }
     }
 }

--- a/web/src/components/integrations/slack/config.rs
+++ b/web/src/components/integrations/slack/config.rs
@@ -16,10 +16,11 @@ use chrono::{Local, SecondsFormat};
 
 use universal_inbox::{
     integration_connection::{
+        IntegrationConnectionId,
         config::IntegrationConnectionConfig,
         integrations::slack::{
-            SlackConfig, SlackContext, SlackMessageConfig, SlackReactionConfig,
-            SlackSyncTaskConfig, SlackSyncType,
+            SlackConfig, SlackContext, SlackEmojiSuggestion, SlackMessageConfig,
+            SlackReactionConfig, SlackSyncTaskConfig, SlackSyncType,
         },
     },
     slack_bridge::SlackBridgeStatus,
@@ -45,6 +46,7 @@ pub fn SlackProviderConfiguration(
     config: ReadSignal<SlackConfig>,
     context: ReadSignal<Option<Option<SlackContext>>>,
     provider_user_id: ReadSignal<Option<Option<String>>>,
+    connection_id: ReadSignal<IntegrationConnectionId>,
     ui_model: Signal<UniversalInboxUIModel>,
     on_config_change: EventHandler<IntegrationConnectionConfig>,
 ) -> Element {
@@ -104,7 +106,7 @@ pub fn SlackProviderConfiguration(
                     id: "slack-config-tab-reaction",
                     role: "tabpanel",
                     class: "bg-base-100 border-base-300 p-6 rounded-b-md flex flex-col gap-2",
-                    SlackReactionConfiguration { config, ui_model, on_config_change }
+                    SlackReactionConfiguration { config, connection_id, ui_model, on_config_change }
                 }
 
                 div {
@@ -128,6 +130,7 @@ pub fn SlackProviderConfiguration(
 #[component]
 fn SlackReactionConfiguration(
     config: ReadSignal<SlackConfig>,
+    connection_id: ReadSignal<IntegrationConnectionId>,
     ui_model: Signal<UniversalInboxUIModel>,
     on_config_change: EventHandler<IntegrationConnectionConfig>,
 ) -> Element {
@@ -197,27 +200,30 @@ fn SlackReactionConfiguration(
                 class: "label-text cursor-pointer grow text-sm text-base-content",
                 "Emoji reaction to synchronize"
             }
-            FloatingLabelSelect::<String> {
-                label: None,
-                class: "max-w-xs",
+            FloatingLabelInputSearchSelect::<SlackEmojiSuggestion> {
                 name: "reaction-name-input".to_string(),
-                required: true,
-                default_value: default_emoji(),
-                on_select: move |reaction: Option<String>| {
+                class: "max-w-xs",
+                data_select: json!({
+                    "value": default_emoji(),
+                    "apiUrl": format!("{api_base_url}integration-connections/{}/slack/emojis/search", connection_id()),
+                    "apiSearchQueryKey": "matches",
+                    "apiFieldsMap": {
+                        "id": "name",
+                        "val": "name",
+                        "title": "display_name"
+                    }
+                }),
+                on_select: move |emoji: Option<SlackEmojiSuggestion>| {
                     on_config_change.call(IntegrationConnectionConfig::Slack(SlackConfig {
                         reaction_config: SlackReactionConfig {
-                            reaction_name: SlackReactionName(reaction.unwrap_or("eyes".to_string())),
+                            reaction_name: SlackReactionName(
+                                emoji.map(|e| e.name).unwrap_or("eyes".to_string())
+                            ),
                             ..config().reaction_config
                         },
                         ..config()
                     }));
                 },
-
-                option { selected: default_emoji() == *"eyes", value: "eyes", "👀 :eyes:" }
-                option { selected: default_emoji() == *"raising_hand", value: "raising_hand", "🙋 :raising_hand:" }
-                option { selected: default_emoji() == *"inbox_tray", value: "inbox_tray", "📥 :inbox_tray:" }
-                option { selected: default_emoji() == *"white_check_mark", value: "white_check_mark", "✅ :white_check_mark:" }
-                option { selected: default_emoji() == *"bookmark", value: "bookmark", "🔖 :bookmark:" }
             }
         }
 

--- a/web/src/components/integrations_panel.rs
+++ b/web/src/components/integrations_panel.rs
@@ -17,7 +17,7 @@ use log::warn;
 use universal_inbox::{
     IntegrationProviderStaticConfig,
     integration_connection::{
-        IntegrationConnection, IntegrationConnectionStatus,
+        IntegrationConnection, IntegrationConnectionId, IntegrationConnectionStatus,
         config::IntegrationConnectionConfig,
         provider::{IntegrationProvider, IntegrationProviderKind},
     },
@@ -487,12 +487,14 @@ pub fn IntegrationSettings(
                     if let Some(Some(connection)) = connection() {
                         {
                             let provider_user_id = connection.provider_user_id.clone();
+                            let connection_id = connection.id;
                             rsx! {
                                 IntegrationConnectionProviderConfiguration {
                                     ui_model: ui_model,
                                     on_config_change: move |c| on_config_change.call((connection.clone(), c)),
                                     provider: provider.clone(),
                                     provider_user_id,
+                                    connection_id,
                                 }
                             }
                         }
@@ -525,6 +527,7 @@ pub fn IconForAction(action: String) -> Element {
 pub fn IntegrationConnectionProviderConfiguration(
     provider: IntegrationProvider,
     provider_user_id: ReadSignal<Option<Option<String>>>,
+    connection_id: ReadSignal<IntegrationConnectionId>,
     ui_model: Signal<UniversalInboxUIModel>,
     on_config_change: EventHandler<IntegrationConnectionConfig>,
 ) -> Element {
@@ -574,6 +577,7 @@ pub fn IntegrationConnectionProviderConfiguration(
                 config: config.clone(),
                 context: context.clone(),
                 provider_user_id,
+                connection_id,
             }
         },
         _ => rsx! {},


### PR DESCRIPTION
## Summary

- Replace the hardcoded 5-emoji dropdown in Slack integration settings with a searchable selector backed by a new API endpoint
- Search standard Unicode emojis first (via the `emojis` crate), then fill remaining slots with workspace custom emojis from Slack's `emoji.list` API (cached 24h in Redis)
- Endpoint is scoped to a specific integration connection — `GET /integration-connections/{id}/slack/emojis/search?matches=…` — to keep the door open for multiple Slack connections per user
- Graceful degradation: if the workspace emoji list fails, the search still returns matching standard emojis and logs a warning
- Frontend reuses the existing `FloatingLabelInputSearchSelect` component; `connection_id` is threaded through `IntegrationConnectionProviderConfiguration` → `SlackProviderConfiguration`

## Test plan

- [ ] `just api test` — root + API unit tests pass (6 new tests for `search_emojis_by_shortcode`)
- [ ] Manual: open Slack integration settings, search the emoji selector by typing (`rock`, `eye`, `party`, …) and verify results appear with emoji character + shortcode
- [ ] Manual: select a new emoji, save, reload settings, confirm selection persists
- [ ] Manual: verify the browser network tab shows `GET /integration-connections/{id}/slack/emojis/search?matches=…` returning 200 with a JSON array of `{name, display_name}` objects
- [ ] Manual: empty query returns `[]`, nonexistent query returns `[]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/universal-inbox/universal-inbox/pull/155" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Searchable Slack reaction emoji picker in integration settings (shows standard Unicode first, then workspace custom emojis).
  * Slack browser-extension bridge for 2-way delete/unsubscribe sync with action state tracking and bridge status in the integration card and Extension settings (enabled by default for new Slack connections).

* **Bug Fixes**
  * Slack custom emojis are now scoped per workspace to prevent cross-workspace leakage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->