### PR TITLE
Switch Slack preview to direct HTML rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,7 +325,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "generic-array",
 ]
 
@@ -864,7 +864,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -874,6 +874,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1161,7 +1170,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "inout",
 ]
 
@@ -1213,6 +1222,12 @@ checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "color-backtrace"
@@ -1338,6 +1353,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-serialize"
@@ -1467,10 +1488,10 @@ dependencies = [
  "aes-gcm",
  "base64 0.20.0",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "percent-encoding",
  "rand 0.8.5",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "time",
  "version_check",
@@ -1618,6 +1639,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "csp"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1716,6 +1746,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1724,7 +1763,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -1896,7 +1935,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -2025,10 +2064,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -2419,10 +2470,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "838b9b441a95da62b39cae4defd240b5ebb0ec9f2daea1126099e00a838dc86f"
 dependencies = [
  "base16",
- "digest",
+ "digest 0.10.7",
  "proc-macro2",
  "quote",
- "sha2",
+ "sha2 0.10.9",
  "slab",
  "syn 2.0.114",
 ]
@@ -2606,7 +2657,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -2632,7 +2683,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -2654,7 +2705,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -3107,11 +3158,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3452,7 +3505,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -3461,7 +3514,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -3482,6 +3544,15 @@ dependencies = [
  "cfg-if",
  "libc",
  "windows-link",
+]
+
+[[package]]
+name = "html-escape"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
+dependencies = [
+ "utf8-width",
 ]
 
 [[package]]
@@ -3578,6 +3649,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -4182,7 +4262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1670343e58806300d87950e3401e820b519b9384281bbabfb15e3636689ffd69"
 dependencies = [
  "crc",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4322,7 +4402,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4660,7 +4740,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "url",
 ]
@@ -4732,7 +4812,7 @@ dependencies = [
  "chrono",
  "dyn-clone",
  "ed25519-dalek",
- "hmac",
+ "hmac 0.12.1",
  "http 1.4.0",
  "itertools 0.10.5",
  "log",
@@ -4747,7 +4827,7 @@ dependencies = [
  "serde_path_to_error",
  "serde_plain",
  "serde_with",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "thiserror 1.0.69",
  "url",
@@ -4947,7 +5027,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4959,7 +5039,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -5037,8 +5117,8 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
- "hmac",
+ "digest 0.10.7",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -5266,7 +5346,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.28.0",
  "tracing",
  "url",
  "zip",
@@ -5940,7 +6020,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -6050,8 +6130,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -6647,7 +6727,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -6664,7 +6744,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -6684,9 +6775,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.18"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
 dependencies = [
  "cc",
  "libc",
@@ -6705,9 +6796,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-tokio"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213241f76fb1e37e27de3b6aa1b068a2c333233b59cca6634f634b80a27ecf1e"
+checksum = "e513e435a8898a0002270f29d0a708b7879708fb5c4d00e46983ca2d2d378cf0"
 dependencies = [
  "futures-core",
  "libc",
@@ -6721,7 +6812,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -6757,12 +6848,13 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slack-blocks-render"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1ac3b5ccd1c5032a8a8ea3e105ef260d31d55a66355f7909b8fba8d3f3229c"
+checksum = "5e808b1f62537e6b6d61fc730aeb2f51d4a2c54de6aa25a7a33230bb65b55e25"
 dependencies = [
  "despatma",
  "emojis 0.7.2",
+ "html-escape",
  "serde",
  "serde_json",
  "slack-morphism",
@@ -6771,9 +6863,9 @@ dependencies = [
 
 [[package]]
 name = "slack-morphism"
-version = "2.17.0"
+version = "2.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c3c0efb5aed37ff5ae893889ffb32599683a2ab319b5ab861085663d7b71a7"
+checksum = "6048a8e61c2ceb5dc31f7f335f9290f4ed905a3d14ca0be5a4907b8fa9ee5713"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -6785,7 +6877,7 @@ dependencies = [
  "futures-locks",
  "futures-util",
  "hex",
- "hmac",
+ "hmac 0.13.0",
  "http 1.4.0",
  "http-body-util",
  "hyper",
@@ -6794,19 +6886,19 @@ dependencies = [
  "lazy_static",
  "mime",
  "mime_guess",
- "rand 0.9.2",
+ "rand 0.10.0",
  "rsb_derive",
  "rvstruct",
  "serde",
  "serde_json",
  "serde_with",
- "sha2",
+ "sha2 0.11.0",
  "signal-hook",
  "signal-hook-tokio",
  "subtle",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tracing",
  "url",
 ]
@@ -6953,7 +7045,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
@@ -6991,7 +7083,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -7014,7 +7106,7 @@ dependencies = [
  "bytes",
  "chrono",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -7024,7 +7116,7 @@ dependencies = [
  "generic-array",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "itoa",
  "log",
  "md-5",
@@ -7035,7 +7127,7 @@ dependencies = [
  "rsa",
  "serde",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -7064,7 +7156,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "home",
  "itoa",
  "log",
@@ -7074,7 +7166,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -7600,13 +7692,25 @@ dependencies = [
  "futures-util",
  "log",
  "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tungstenite 0.28.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
  "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
- "tungstenite 0.28.0",
+ "tungstenite 0.29.0",
 ]
 
 [[package]]
@@ -7943,11 +8047,27 @@ dependencies = [
  "log",
  "native-tls",
  "rand 0.9.2",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.9.2",
  "rustls",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
- "utf-8",
 ]
 
 [[package]]
@@ -8041,7 +8161,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "subtle",
 ]
 
@@ -8057,6 +8177,7 @@ dependencies = [
  "emojis 0.8.0",
  "enum_derive",
  "git-url-parse",
+ "html-escape",
  "macro-attr",
  "num_enum",
  "openidconnect",
@@ -8192,6 +8313,7 @@ dependencies = [
  "emojis 0.8.0",
  "futures-util",
  "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "gloo-timers",
  "gloo-utils",
  "gravatar-rs",
@@ -8261,6 +8383,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
 
 [[package]]
 name = "utf8_iter"
@@ -9442,7 +9570,7 @@ dependencies = [
  "flate2",
  "generic-array",
  "getrandom 0.3.4",
- "hmac",
+ "hmac 0.12.1",
  "indexmap 2.13.0",
  "lzma-rust2",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6848,9 +6848,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slack-blocks-render"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e808b1f62537e6b6d61fc730aeb2f51d4a2c54de6aa25a7a33230bb65b55e25"
+checksum = "264b83f5f9bba1e039ed333a2b492fa0f0526dfc2fa1b499c26058ede7a65893"
 dependencies = [
  "despatma",
  "emojis 0.7.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 serde_urlencoded = { version = "0.7.0" }
 serde_with = { version = "3.8.0" }
-slack-blocks-render = { version = "0.5.0" }
+slack-blocks-render = { version = "0.5.1" }
 slack-morphism = { version = "2.20.0" }
 strum = { version = "0.27.1", features = ["derive"] }
 thiserror = { version = "2.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ clap = { workspace = true }
 email_address = { workspace = true }
 emojis = { workspace = true }
 enum_derive = { workspace = true }
+html-escape = "0.2"
 git-url-parse = { version = "0.6.0", features = ["serde"] }
 macro-attr = { workspace = true }
 num_enum = "0.7.5"
@@ -71,8 +72,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 serde_urlencoded = { version = "0.7.0" }
 serde_with = { version = "3.8.0" }
-slack-blocks-render = { version = "0.4.2" }
-slack-morphism = { version = "2.17.0" }
+slack-blocks-render = { version = "0.5.0" }
+slack-morphism = { version = "2.20.0" }
 strum = { version = "0.27.1", features = ["derive"] }
 thiserror = { version = "2.0" }
 tracing = { version = "0.1.0", features = ["log"] }

--- a/api/src/integrations/slack.rs
+++ b/api/src/integrations/slack.rs
@@ -154,6 +154,60 @@ impl SlackService {
         Ok(())
     }
 
+    async fn create_bridge_pending_action_if_enabled(
+        &self,
+        executor: &mut Transaction<'_, Postgres>,
+        source_item: &ThirdPartyItem,
+        user_id: UserId,
+        action_type: universal_inbox::slack_bridge::SlackBridgeActionType,
+    ) -> Result<(), UniversalInboxError> {
+        let ThirdPartyItemData::SlackThread(slack_thread) = &source_item.data else {
+            return Ok(()); // Not a SlackThread — no-op
+        };
+
+        // Check if extension bridge is enabled for this user
+        let integration_connection_service = self.integration_connection_service.read().await;
+        let (_, integration_connection) = match integration_connection_service
+            .find_access_token(executor, IntegrationProviderKind::Slack, user_id)
+            .await?
+        {
+            Some(result) => result,
+            None => return Ok(()), // No Slack connection
+        };
+
+        let extension_enabled = match &integration_connection.provider {
+            universal_inbox::integration_connection::provider::IntegrationProvider::Slack {
+                config,
+                ..
+            } => config.message_config.extension_enabled,
+            _ => false,
+        };
+
+        if !extension_enabled {
+            return Ok(());
+        }
+
+        let team_id = slack_thread.team.id.clone();
+        let channel_id = slack_thread.channel.id.clone();
+        let thread_ts = slack_thread.messages.first().origin.ts.clone();
+        let last_message_ts = slack_thread.messages.last().origin.ts.clone();
+
+        self.slack_bridge_service
+            .create_pending_action(
+                executor,
+                user_id,
+                None,
+                action_type,
+                team_id,
+                channel_id,
+                thread_ts,
+                last_message_ts,
+            )
+            .await?;
+
+        Ok(())
+    }
+
     pub fn build_slack_client(
         &self,
     ) -> Result<SlackClient<SlackClientHyperHttpsConnector>, UniversalInboxError> {

--- a/api/src/integrations/slack.rs
+++ b/api/src/integrations/slack.rs
@@ -154,60 +154,6 @@ impl SlackService {
         Ok(())
     }
 
-    async fn create_bridge_pending_action_if_enabled(
-        &self,
-        executor: &mut Transaction<'_, Postgres>,
-        source_item: &ThirdPartyItem,
-        user_id: UserId,
-        action_type: universal_inbox::slack_bridge::SlackBridgeActionType,
-    ) -> Result<(), UniversalInboxError> {
-        let ThirdPartyItemData::SlackThread(slack_thread) = &source_item.data else {
-            return Ok(()); // Not a SlackThread — no-op
-        };
-
-        // Check if extension bridge is enabled for this user
-        let integration_connection_service = self.integration_connection_service.read().await;
-        let (_, integration_connection) = match integration_connection_service
-            .find_access_token(executor, IntegrationProviderKind::Slack, user_id)
-            .await?
-        {
-            Some(result) => result,
-            None => return Ok(()), // No Slack connection
-        };
-
-        let extension_enabled = match &integration_connection.provider {
-            universal_inbox::integration_connection::provider::IntegrationProvider::Slack {
-                config,
-                ..
-            } => config.message_config.extension_enabled,
-            _ => false,
-        };
-
-        if !extension_enabled {
-            return Ok(());
-        }
-
-        let team_id = slack_thread.team.id.clone();
-        let channel_id = slack_thread.channel.id.clone();
-        let thread_ts = slack_thread.messages.first().origin.ts.clone();
-        let last_message_ts = slack_thread.messages.last().origin.ts.clone();
-
-        self.slack_bridge_service
-            .create_pending_action(
-                executor,
-                user_id,
-                None,
-                action_type,
-                team_id,
-                channel_id,
-                thread_ts,
-                last_message_ts,
-            )
-            .await?;
-
-        Ok(())
-    }
-
     pub fn build_slack_client(
         &self,
     ) -> Result<SlackClient<SlackClientHyperHttpsConnector>, UniversalInboxError> {
@@ -628,6 +574,7 @@ impl SlackService {
         message_content: &SlackMessageContent,
         user_id: UserId,
         slack_api_token: &SlackApiToken,
+        provider_user_id: Option<&str>,
     ) -> Result<Option<SlackReferences>, UniversalInboxError> {
         let mut references = find_slack_references_in_message(message_content);
 
@@ -655,13 +602,28 @@ impl SlackService {
         }
 
         let slack_usergroup_ids = references.usergroups.keys().cloned().collect::<Vec<_>>();
-        for slack_usergroup_id in slack_usergroup_ids {
+        for slack_usergroup_id in &slack_usergroup_ids {
             let usergroup = self
-                .fetch_usergroup(&slack_usergroup_id, user_id, slack_api_token)
+                .fetch_usergroup(slack_usergroup_id, user_id, slack_api_token)
                 .await?;
             references
                 .usergroups
                 .insert(slack_usergroup_id.clone(), Some(usergroup.handle));
+        }
+
+        if let Some(user_slack_id) = provider_user_id {
+            let mut highlighted = Vec::new();
+            for usergroup_id in &slack_usergroup_ids {
+                let members = self
+                    .list_users_in_usergroup(usergroup_id, slack_api_token)
+                    .await?;
+                if members.iter().any(|id| id.0 == user_slack_id) {
+                    highlighted.push(usergroup_id.clone());
+                }
+            }
+            if !highlighted.is_empty() {
+                references.usergroup_ids_to_highlight = Some(highlighted);
+            }
         }
 
         let slack_channel_ids = references.channels.keys().cloned().collect::<Vec<_>>();
@@ -742,6 +704,7 @@ impl SlackService {
                         &message.content,
                         user_id,
                         &slack_api_token,
+                        integration_connection.provider_user_id.as_deref(),
                     )
                     .await
                     .inspect_err(|err| {
@@ -853,6 +816,7 @@ impl SlackService {
                     &message.content,
                     user_id,
                     &slack_api_token,
+                    integration_connection.provider_user_id.as_deref(),
                 )
                 .await
                 .inspect_err(|err| {
@@ -1411,6 +1375,7 @@ impl ThirdPartyItemSourceService<SlackThread> for SlackService {
                         &message.content,
                         user_id,
                         &slack_api_token,
+                        integration_connection.provider_user_id.as_deref(),
                     )
                     .await
                     .inspect_err(|err| {

--- a/api/tests/api/helpers/notification/slack.rs
+++ b/api/tests/api/helpers/notification/slack.rs
@@ -387,6 +387,7 @@ pub fn slack_reacted_message() -> Box<SlackReactionItem> {
                     )),
                 ),
             ]),
+            ..SlackReferences::default()
         }),
     }))
 }

--- a/api/tests/api/test_slack_tasks.rs
+++ b/api/tests/api/test_slack_tasks.rs
@@ -37,9 +37,9 @@ use crate::helpers::{
         slack::{
             mock_slack_fetch_channel, mock_slack_fetch_reply, mock_slack_fetch_team,
             mock_slack_fetch_user, mock_slack_get_chat_permalink, mock_slack_list_emojis,
-            mock_slack_list_usergroups, mock_slack_reactions_add, mock_slack_reactions_remove,
-            slack_push_reaction_added_event, slack_push_reaction_removed_event,
-            slack_reacted_message,
+            mock_slack_list_usergroups, mock_slack_list_users_in_usergroup,
+            mock_slack_reactions_add, mock_slack_reactions_remove, slack_push_reaction_added_event,
+            slack_push_reaction_removed_event, slack_reacted_message,
         },
     },
     rest::{create_resource, create_resource_response, get_resource, patch_resource},
@@ -136,6 +136,12 @@ async fn test_sync_todoist_slack_task(
         "slack_list_usergroups_response.json",
     )
     .await;
+    mock_slack_list_users_in_usergroup(
+        &app.app.slack_mock_server,
+        "S05ZZZ",
+        "slack_list_users_in_usergroup_response.json",
+    )
+    .await;
 
     let _todoist_projects_mock = mock_todoist_sync_resources_service(
         &app.app.todoist_mock_server,
@@ -176,7 +182,7 @@ $ echo Hello world
 \
 _Some_ `formatted` ~text~.\
 \
-Here is a [link](https://www.universal-inbox.com)@@john.doe@@@admins@#universal-inbox
+Here is a [link](https://www.universal-inbox.com/)@@john.doe@@@admins@#universal-inbox
 👋![:unknown2:](https://emoji.com/unknown2.png)"#
                 .to_string(),
         ),
@@ -385,7 +391,7 @@ $ echo Hello world
 \
 _Some_ `formatted` ~text~.\
 \
-Here is a [link](https://www.universal-inbox.com)@@john.doe@@@admins@#universal-inbox
+Here is a [link](https://www.universal-inbox.com/)@@john.doe@@@admins@#universal-inbox
 👋![:unknown2:](https://emoji.com/unknown2.png)"#
                 .to_string(),
         ),

--- a/api/tests/api/test_slack_webhook_message.rs
+++ b/api/tests/api/test_slack_webhook_message.rs
@@ -1224,19 +1224,23 @@ fn add_user_ref_in_message(slack_push_message_event: &mut SlackPushEventCallback
     else {
         unreachable!("Unexpected event type");
     };
-    content.blocks = Some(vec![SlackBlock::RichText(serde_json::json!({
-    "block_id": "12345",
-    "elements": [
-        {
-            "type": "rich_text_section",
+    content.blocks = Some(vec![SlackBlock::RichText(
+        serde_json::from_value(serde_json::json!({
+            "block_id": "12345",
             "elements": [
                 {
-                    "type": "user",
-                    "user_id": user_id
-                }
+                    "type": "rich_text_section",
+                    "elements": [
+                        {
+                            "type": "user",
+                            "user_id": user_id
+                        }
+                    ]
+                },
             ]
-        },
-    ]}))]);
+        }))
+        .unwrap(),
+    )]);
 }
 
 fn add_usergroup_ref_in_message(
@@ -1254,17 +1258,21 @@ fn add_usergroup_ref_in_message(
     else {
         unreachable!("Unexpected event type");
     };
-    content.blocks = Some(vec![SlackBlock::RichText(serde_json::json!({
-    "block_id": "12345",
-    "elements": [
-        {
-            "type": "rich_text_section",
+    content.blocks = Some(vec![SlackBlock::RichText(
+        serde_json::from_value(serde_json::json!({
+            "block_id": "12345",
             "elements": [
                 {
-                    "type": "usergroup",
-                    "usergroup_id": usergroup_id
-                }
+                    "type": "rich_text_section",
+                    "elements": [
+                        {
+                            "type": "usergroup",
+                            "usergroup_id": usergroup_id
+                        }
+                    ]
+                },
             ]
-        },
-    ]}))]);
+        }))
+        .unwrap(),
+    )]);
 }

--- a/api/tests/api/test_slack_webhook_star_reaction.rs
+++ b/api/tests/api/test_slack_webhook_star_reaction.rs
@@ -42,8 +42,8 @@ use crate::helpers::{
         slack::{
             mock_slack_fetch_channel, mock_slack_fetch_reply, mock_slack_fetch_team,
             mock_slack_fetch_user, mock_slack_get_chat_permalink, mock_slack_list_emojis,
-            mock_slack_list_usergroups, slack_push_reaction_added_event,
-            slack_push_reaction_removed_event,
+            mock_slack_list_usergroups, mock_slack_list_users_in_usergroup,
+            slack_push_reaction_added_event, slack_push_reaction_removed_event,
         },
     },
     rest::create_resource_response,
@@ -270,6 +270,12 @@ async fn test_receive_reaction_added_event_as_notification(
         "slack_list_usergroups_response.json",
     )
     .await;
+    mock_slack_list_users_in_usergroup(
+        &app.app.slack_mock_server,
+        "S05ZZZ",
+        "slack_list_users_in_usergroup_response.json",
+    )
+    .await;
 
     let response = create_resource_response(
         &app.client,
@@ -343,6 +349,7 @@ async fn test_receive_reaction_added_event_as_notification(
                     ))
                 )
             ]),
+            ..SlackReferences::default()
         })
     );
     match &message.sender {
@@ -440,6 +447,12 @@ async fn test_receive_reaction_removed_event_as_notification(
     let _slack_list_usergroups_mock = mock_slack_list_usergroups(
         &app.app.slack_mock_server,
         "slack_list_usergroups_response.json",
+    )
+    .await;
+    mock_slack_list_users_in_usergroup(
+        &app.app.slack_mock_server,
+        "S05ZZZ",
+        "slack_list_users_in_usergroup_response.json",
     )
     .await;
 
@@ -583,6 +596,12 @@ async fn test_receive_reaction_added_event_as_task(
         "slack_list_usergroups_response.json",
     )
     .await;
+    mock_slack_list_users_in_usergroup(
+        &app.app.slack_mock_server,
+        "S05ZZZ",
+        "slack_list_users_in_usergroup_response.json",
+    )
+    .await;
 
     let _todoist_projects_mock = mock_todoist_sync_resources_service(
         &app.app.todoist_mock_server,
@@ -613,7 +632,7 @@ $ echo Hello world
 \
 _Some_ `formatted` ~text~.\
 \
-Here is a [link](https://www.universal-inbox.com)@@john.doe@@@admins@#universal-inbox
+Here is a [link](https://www.universal-inbox.com/)@@john.doe@@@admins@#universal-inbox
 👋![:unknown2:](https://emoji.com/unknown2.png)"#
                 .to_string(),
         ),
@@ -748,6 +767,12 @@ async fn test_receive_reaction_removed_and_added_event_as_task(
         "slack_list_usergroups_response.json",
     )
     .await;
+    mock_slack_list_users_in_usergroup(
+        &app.app.slack_mock_server,
+        "S05ZZZ",
+        "slack_list_users_in_usergroup_response.json",
+    )
+    .await;
 
     let _todoist_projects_mock = mock_todoist_sync_resources_service(
         &app.app.todoist_mock_server,
@@ -778,7 +803,7 @@ $ echo Hello world
 \
 _Some_ `formatted` ~text~.\
 \
-Here is a [link](https://www.universal-inbox.com)@@john.doe@@@admins@#universal-inbox
+Here is a [link](https://www.universal-inbox.com/)@@john.doe@@@admins@#universal-inbox
 👋![:unknown2:](https://emoji.com/unknown2.png)"#
                 .to_string(),
         ),

--- a/src/third_party/integrations/slack.rs
+++ b/src/third_party/integrations/slack.rs
@@ -6,7 +6,7 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 use slack_blocks_render::{
     SlackReferences, html::render_blocks_as_html, render_blocks_as_markdown,
-    text::render_blocks_as_text,
+    render_slack_mrkdwn_text_as_html, text::render_blocks_as_text,
 };
 use slack_morphism::prelude::*;
 use url::Url;
@@ -279,16 +279,20 @@ impl SlackMessageRender for SlackHistoryMessage {
                     }
 
                     if let Some(text) = a.text.as_ref() {
-                        let sanitized = sanitize_slack_markdown(text);
-                        let sanitized_text = html_escape::encode_text(&sanitized);
+                        let rendered_text = render_slack_mrkdwn_text_as_html(
+                            text,
+                            &references.clone().unwrap_or_default(),
+                            default_style_class,
+                            highlight_style_class,
+                        );
                         if let Some(title) = a.title.as_ref() {
                             let escaped_title = html_escape::encode_text(title);
                             return Some(format!(
-                                "<p>{escaped_title}</p>\n<p>{sanitized_text}</p>\n",
+                                "<p>{escaped_title}</p>\n<p>{rendered_text}</p>\n",
                             ));
                         }
 
-                        return Some(format!("<p>{sanitized_text}</p>\n"));
+                        return Some(format!("<p>{rendered_text}</p>\n"));
                     }
 
                     None
@@ -300,14 +304,19 @@ impl SlackMessageRender for SlackHistoryMessage {
             }
         }
 
-        let message = match &self.content.text {
-            Some(text) => sanitize_slack_markdown(text),
-            _ => "A slack message".to_string(),
+        let text = match &self.content.text {
+            Some(text) => text.as_str(),
+            _ => "A slack message",
         };
 
         format!(
             "<p>{}</p>\n",
-            html_escape::encode_text(&replace_emoji_code_in_string_with_emoji(&message))
+            render_slack_mrkdwn_text_as_html(
+                text,
+                &references.unwrap_or_default(),
+                default_style_class,
+                highlight_style_class,
+            )
         )
     }
 
@@ -835,6 +844,93 @@ Here is a [link](https://www.universal-inbox.com/)"#
             message.message.content.text = Some("Test message".to_string());
             message.message.content.blocks = Some(vec![]);
             assert_eq!(slack_message.render_content(), "Test message".to_string());
+        }
+    }
+
+    mod test_message_content_as_html {
+        use super::*;
+
+        fn render_html(slack_message: &SlackMessageDetails) -> String {
+            slack_message.render_content_as_html("text-primary", "text-warning", None)
+        }
+
+        #[rstest]
+        fn test_render_message_with_blocks(slack_message: SlackMessageDetails) {
+            let html = render_html(&slack_message);
+            // Blocks path delegates to render_blocks_as_html — verify it produces HTML tags
+            assert!(html.contains("<strong>"), "Expected HTML bold tag: {html}");
+            assert!(html.contains("<a "), "Expected HTML link tag: {html}");
+        }
+
+        #[rstest]
+        fn test_render_attachment_text_with_slack_link(mut slack_message: SlackMessageDetails) {
+            let message = &mut slack_message;
+            message.message.content.attachments = Some(vec![SlackMessageAttachment {
+                id: None,
+                color: None,
+                fallback: None,
+                title: None,
+                fields: None,
+                mrkdwn_in: None,
+                text: Some("Check <https://example.com|this link>".to_string()),
+                blocks: None,
+            }]);
+            message.message.content.blocks = Some(vec![]);
+            let html = render_html(&slack_message);
+            assert!(
+                html.contains(r#"<a target="_blank" rel="noopener noreferrer" href="https://example.com">this link</a>"#),
+                "Slack link should render as HTML anchor: {html}"
+            );
+            assert!(
+                !html.contains("[this link]"),
+                "Should not contain raw Markdown link syntax: {html}"
+            );
+        }
+
+        #[rstest]
+        fn test_render_attachment_text_with_title(mut slack_message: SlackMessageDetails) {
+            let message = &mut slack_message;
+            message.message.content.attachments = Some(vec![SlackMessageAttachment {
+                id: None,
+                color: None,
+                fallback: None,
+                title: Some("The title".to_string()),
+                fields: None,
+                mrkdwn_in: None,
+                text: Some("*bold text*".to_string()),
+                blocks: None,
+            }]);
+            message.message.content.blocks = Some(vec![]);
+            let html = render_html(&slack_message);
+            assert!(
+                html.contains("<p>The title</p>"),
+                "Title should be in its own paragraph: {html}"
+            );
+            assert!(
+                html.contains("<strong>bold text</strong>"),
+                "Text should have bold rendered as HTML: {html}"
+            );
+        }
+
+        #[rstest]
+        fn test_render_plain_text_fallback_with_slack_link(mut slack_message: SlackMessageDetails) {
+            let message = &mut slack_message;
+            message.message.content.text = Some("Visit <https://example.com|our site>".to_string());
+            message.message.content.blocks = Some(vec![]);
+            let html = render_html(&slack_message);
+            assert!(
+                html.contains(r#"href="https://example.com">our site</a>"#),
+                "Slack link should render as HTML anchor: {html}"
+            );
+        }
+
+        #[rstest]
+        fn test_render_plain_text_fallback_simple(mut slack_message: SlackMessageDetails) {
+            let message = &mut slack_message;
+            message.message.content.text = Some("Simple & plain".to_string());
+            message.message.content.blocks = Some(vec![]);
+            let html = render_html(&slack_message);
+            assert_eq!(html, "<p>Simple &amp; plain</p>\n");
         }
     }
 

--- a/src/third_party/integrations/slack.rs
+++ b/src/third_party/integrations/slack.rs
@@ -5,7 +5,8 @@ use chrono::{DateTime, Timelike, Utc};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use slack_blocks_render::{
-    SlackReferences, render_blocks_as_markdown, text::render_blocks_as_text,
+    SlackReferences, html::render_blocks_as_html, render_blocks_as_markdown,
+    text::render_blocks_as_text,
 };
 use slack_morphism::prelude::*;
 use url::Url;
@@ -162,6 +163,13 @@ impl HasHtmlUrl for SlackMessageDetails {
 
 pub trait SlackMessageRender {
     fn render_content(&self, references: Option<SlackReferences>, as_markdown: bool) -> String;
+    fn render_content_as_html(
+        &self,
+        references: Option<SlackReferences>,
+        default_style_class: &str,
+        highlight_style_class: &str,
+        user_slack_id: Option<String>,
+    ) -> String;
     fn render_title(&self, references: Option<SlackReferences>) -> String;
     fn get_sender(
         &self,
@@ -232,6 +240,77 @@ impl SlackMessageRender for SlackHistoryMessage {
         replace_emoji_code_in_string_with_emoji(&message)
     }
 
+    fn render_content_as_html(
+        &self,
+        references: Option<SlackReferences>,
+        default_style_class: &str,
+        highlight_style_class: &str,
+        user_slack_id: Option<String>,
+    ) -> String {
+        let references = references.map(|mut refs| {
+            refs.user_id_to_highlight = user_slack_id.map(SlackUserId);
+            refs
+        });
+
+        if let Some(blocks) = &self.content.blocks
+            && !blocks.is_empty()
+        {
+            return render_blocks_as_html(
+                blocks.clone(),
+                references.clone().unwrap_or_default(),
+                default_style_class,
+                highlight_style_class,
+            );
+        }
+
+        if let Some(attachments) = &self.content.attachments
+            && !attachments.is_empty()
+        {
+            let str_blocks = attachments
+                .iter()
+                .filter_map(|a| {
+                    if let Some(blocks) = a.blocks.as_ref() {
+                        return Some(render_blocks_as_html(
+                            blocks.clone(),
+                            references.clone().unwrap_or_default(),
+                            default_style_class,
+                            highlight_style_class,
+                        ));
+                    }
+
+                    if let Some(text) = a.text.as_ref() {
+                        let sanitized = sanitize_slack_markdown(text);
+                        let sanitized_text = html_escape::encode_text(&sanitized);
+                        if let Some(title) = a.title.as_ref() {
+                            let escaped_title = html_escape::encode_text(title);
+                            return Some(format!(
+                                "<p>{escaped_title}</p>\n<p>{sanitized_text}</p>\n",
+                            ));
+                        }
+
+                        return Some(format!("<p>{sanitized_text}</p>\n"));
+                    }
+
+                    None
+                })
+                .collect::<Vec<String>>();
+
+            if !str_blocks.is_empty() {
+                return str_blocks.join("");
+            }
+        }
+
+        let message = match &self.content.text {
+            Some(text) => sanitize_slack_markdown(text),
+            _ => "A slack message".to_string(),
+        };
+
+        format!(
+            "<p>{}</p>\n",
+            html_escape::encode_text(&replace_emoji_code_in_string_with_emoji(&message))
+        )
+    }
+
     fn render_title(&self, references: Option<SlackReferences>) -> String {
         if let Some(attachments) = &self.content.attachments
             && let Some(first_attachment) = attachments.first()
@@ -300,6 +379,20 @@ impl SlackMessageDetails {
 
     pub fn render_content(&self) -> String {
         self.message.render_content(self.references.clone(), true)
+    }
+
+    pub fn render_content_as_html(
+        &self,
+        default_style_class: &str,
+        highlight_style_class: &str,
+        user_slack_id: Option<String>,
+    ) -> String {
+        self.message.render_content_as_html(
+            self.references.clone(),
+            default_style_class,
+            highlight_style_class,
+            user_slack_id,
+        )
     }
 }
 
@@ -657,7 +750,7 @@ $ echo Hello world
 \
 _Some_ `formatted` ~text~.\
 \
-Here is a [link](https://www.universal-inbox.com)"#
+Here is a [link](https://www.universal-inbox.com/)"#
             );
         }
 
@@ -693,7 +786,7 @@ $ echo Hello world
 \
 _Some_ `formatted` ~text~.\
 \
-Here is a [link](https://www.universal-inbox.com)"#
+Here is a [link](https://www.universal-inbox.com/)"#
             );
         }
 
@@ -797,83 +890,62 @@ Here is a [link](https://www.universal-inbox.com)"#
         #[rstest]
         fn test_render_message_with_blocks_in_attachments(mut slack_message: SlackMessageDetails) {
             let message = &mut slack_message;
-            message.message.content.blocks = Some(vec![SlackBlock::RichText(serde_json::json!({
-                "type": "rich_text",
-                "elements": [
-                    {
-                        "type": "rich_text_section",
-                        "elements": [
-                            {
-                                "type": "user",
-                                "user_id": "user1"
-                            }
-                        ]
-                    },
-                    {
-                        "type": "rich_text_section",
-                        "elements": [
-                            {
-                                "type": "user",
-                                "user_id": "user2"
-                            }
-                        ]
-                    },
-                    {
-                        "type": "rich_text_section",
-                        "elements": [
-                            {
-                                "type": "usergroup",
-                                "usergroup_id": "group1"
-                            }
-                        ]
-                    },
-                    {
-                        "type": "rich_text_section",
-                        "elements": [
-                            {
-                                "type": "usergroup",
-                                "usergroup_id": "group2"
-                            }
-                        ]
-                    },
-                    {
-                        "type": "rich_text_section",
-                        "elements": [
-                            {
-                                "type": "channel",
-                                "channel_id": "C0123456"
-                            }
-                        ]
-                    },
-                    {
-                        "type": "rich_text_section",
-                        "elements": [
-                            {
-                                "type": "channel",
-                                "channel_id": "C0011223"
-                            }
-                        ]
-                    },
-                    {
-                        "type": "rich_text_section",
-                        "elements": [
-                            {
-                                "type": "emoji",
-                                "name": "unknown1"
-                            }
-                        ]
-                    },
-                    {
-                        "type": "rich_text_section",
-                        "elements": [
-                            {
-                                "type": "emoji",
-                                "name": "unknown2"
-                            }
-                        ]
-                    }
-                ]
-            }))]);
+            message.message.content.blocks = Some(vec![SlackBlock::RichText(
+                serde_json::from_value(serde_json::json!({
+                    "type": "rich_text",
+                    "elements": [
+                        {
+                            "type": "rich_text_section",
+                            "elements": [
+                                { "type": "user", "user_id": "user1" }
+                            ]
+                        },
+                        {
+                            "type": "rich_text_section",
+                            "elements": [
+                                { "type": "user", "user_id": "user2" }
+                            ]
+                        },
+                        {
+                            "type": "rich_text_section",
+                            "elements": [
+                                { "type": "usergroup", "usergroup_id": "group1" }
+                            ]
+                        },
+                        {
+                            "type": "rich_text_section",
+                            "elements": [
+                                { "type": "usergroup", "usergroup_id": "group2" }
+                            ]
+                        },
+                        {
+                            "type": "rich_text_section",
+                            "elements": [
+                                { "type": "channel", "channel_id": "C0123456" }
+                            ]
+                        },
+                        {
+                            "type": "rich_text_section",
+                            "elements": [
+                                { "type": "channel", "channel_id": "C0011223" }
+                            ]
+                        },
+                        {
+                            "type": "rich_text_section",
+                            "elements": [
+                                { "type": "emoji", "name": "unknown1" }
+                            ]
+                        },
+                        {
+                            "type": "rich_text_section",
+                            "elements": [
+                                { "type": "emoji", "name": "unknown2" }
+                            ]
+                        }
+                    ]
+                }))
+                .unwrap(),
+            )]);
             message.references = Some(SlackReferences {
                 users: HashMap::from([(
                     SlackUserId("user1".to_string()),
@@ -899,6 +971,7 @@ Here is a [link](https://www.universal-inbox.com)"#
                         )),
                     ),
                 ]),
+                ..SlackReferences::default()
             });
             assert_eq!(
                 slack_message.render_content(),
@@ -966,35 +1039,29 @@ Here is a [link](https://www.universal-inbox.com)"#
             #[rstest]
             fn test_render_thread_with_reference_custom_emoji(mut slack_thread: Box<SlackThread>) {
                 let first_message = slack_thread.messages.first_mut();
-                first_message.content.blocks =
-                    Some(vec![SlackBlock::RichText(serde_json::json!({
+                first_message.content.blocks = Some(vec![SlackBlock::RichText(
+                    serde_json::from_value(serde_json::json!({
                         "type": "rich_text",
                         "elements": [
                             {
                                 "type": "rich_text_section",
                                 "elements": [
-                                    {
-                                        "text": "Hello ",
-                                        "type": "text"
-                                    },
-                                    {
-                                        "type": "emoji",
-                                        "name": "custom_emoji"
-                                    }
+                                    { "text": "Hello ", "type": "text" },
+                                    { "type": "emoji", "name": "custom_emoji" }
                                 ]
                             }
                         ]
-                    }))]);
+                    }))
+                    .unwrap(),
+                )]);
                 let slack_references = SlackReferences {
-                    users: Default::default(),
-                    channels: Default::default(),
-                    usergroups: Default::default(),
                     emojis: HashMap::from([(
                         SlackEmojiName("custom_emoji".to_string()),
                         Some(SlackEmojiRef::Url(
                             "https://emoji.com/custom_emoji.png".parse().unwrap(),
                         )),
                     )]),
+                    ..SlackReferences::default()
                 };
 
                 assert_eq!(

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -97,6 +97,11 @@ features = [
 version = "0.3.4"
 features = ["wasm_js"]
 
+[dependencies.getrandom04]
+package = "getrandom"
+version = "0.4"
+features = ["wasm_js"]
+
 [package.metadata.cargo-machete]
 ignored = ["getrandom"]
 

--- a/web/css/universal-inbox.css
+++ b/web/css/universal-inbox.css
@@ -38,9 +38,10 @@
 @import "../node_modules/notyf/notyf.min.css";
 @import "../node_modules/flyonui/src/vendor/notyf.css";
 
+@source inline("slack-emoji");
 @utility slack-emoji {
     @apply my-0! mx-0.5!;
-    @apply w-4 h-4 inline-block;
+    @apply w-4! h-4! inline-block;
 }
 
 @layer base {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -589,7 +589,6 @@
       "integrity": "sha512-ifjHqLczC81d1xjXPXCzxTFKNOFsEzuuLN44cMnyzQ/GWi4B48fyX7JHndWE7Lxd54cW1O9Ik7AdBN3Gq891EA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@module-federation/runtime-tools": "0.18.0",
         "@rspack/binding": "1.5.2",
@@ -911,7 +910,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3346,8 +3344,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.13.tgz",
       "integrity": "sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/thingies": {
       "version": "2.5.0",
@@ -3435,8 +3432,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/type-is": {
       "version": "1.6.18",

--- a/web/src/components/integrations/slack/preview/channel.rs
+++ b/web/src/components/integrations/slack/preview/channel.rs
@@ -5,7 +5,7 @@ use dioxus_free_icons::{Icon, icons::bs_icons::BsArrowUpRightSquare};
 
 use universal_inbox::{HasHtmlUrl, third_party::integrations::slack::SlackChannelDetails};
 
-use crate::components::{integrations::slack::SlackTeamDisplay, markdown::SlackMarkdown};
+use crate::components::{integrations::slack::SlackTeamDisplay, markdown::Markdown};
 
 #[component]
 pub fn SlackChannelPreview(
@@ -43,7 +43,7 @@ pub fn SlackChannelPreview(
                     class: "flex items-center",
                     href: "{slack_channel().get_html_url()}",
                     target: "_blank",
-                    SlackMarkdown { text: "{title}" }
+                    Markdown { text: "{title}" }
                     Icon { class: "h-5 w-5 min-w-5 text-base-content/50 p-1", icon: BsArrowUpRightSquare }
                 }
             }

--- a/web/src/components/integrations/slack/preview/file.rs
+++ b/web/src/components/integrations/slack/preview/file.rs
@@ -5,7 +5,7 @@ use dioxus_free_icons::{Icon, icons::bs_icons::BsArrowUpRightSquare};
 
 use universal_inbox::{HasHtmlUrl, third_party::integrations::slack::SlackFileDetails};
 
-use crate::components::{integrations::slack::SlackTeamDisplay, markdown::SlackMarkdown};
+use crate::components::{integrations::slack::SlackTeamDisplay, markdown::Markdown};
 
 #[component]
 pub fn SlackFilePreview(
@@ -31,7 +31,7 @@ pub fn SlackFilePreview(
                     class: "flex items-center",
                     href: "{slack_file().get_html_url()}",
                     target: "_blank",
-                    SlackMarkdown { text: "{title}" }
+                    Markdown { text: "{title}" }
                     Icon { class: "h-5 w-5 min-w-5 text-base-content/50 p-1", icon: BsArrowUpRightSquare }
                 }
             }

--- a/web/src/components/integrations/slack/preview/file_comment.rs
+++ b/web/src/components/integrations/slack/preview/file_comment.rs
@@ -5,7 +5,7 @@ use dioxus_free_icons::{Icon, icons::bs_icons::BsArrowUpRightSquare};
 
 use universal_inbox::{HasHtmlUrl, third_party::integrations::slack::SlackFileCommentDetails};
 
-use crate::components::{integrations::slack::SlackTeamDisplay, markdown::SlackMarkdown};
+use crate::components::{integrations::slack::SlackTeamDisplay, markdown::Markdown};
 
 #[component]
 pub fn SlackFileCommentPreview(
@@ -31,7 +31,7 @@ pub fn SlackFileCommentPreview(
                     class: "flex items-center",
                     href: "{slack_file_comment().get_html_url()}",
                     target: "_blank",
-                    SlackMarkdown { text: "{title}" }
+                    Markdown { text: "{title}" }
                     Icon { class: "h-5 w-5 min-w-5 text-base-content/50 p-1", icon: BsArrowUpRightSquare }
                 }
             }

--- a/web/src/components/integrations/slack/preview/group.rs
+++ b/web/src/components/integrations/slack/preview/group.rs
@@ -5,7 +5,7 @@ use dioxus_free_icons::{Icon, icons::bs_icons::BsArrowUpRightSquare};
 
 use universal_inbox::{HasHtmlUrl, third_party::integrations::slack::SlackGroupDetails};
 
-use crate::components::{integrations::slack::SlackTeamDisplay, markdown::SlackMarkdown};
+use crate::components::{integrations::slack::SlackTeamDisplay, markdown::Markdown};
 
 #[component]
 pub fn SlackGroupPreview(
@@ -31,7 +31,7 @@ pub fn SlackGroupPreview(
                     class: "flex items-center",
                     href: "{slack_group().get_html_url()}",
                     target: "_blank",
-                    SlackMarkdown { text: "{title}" }
+                    Markdown { text: "{title}" }
                     Icon { class: "h-5 w-5 min-w-5 text-base-content/50 p-1", icon: BsArrowUpRightSquare }
                 }
             }

--- a/web/src/components/integrations/slack/preview/im.rs
+++ b/web/src/components/integrations/slack/preview/im.rs
@@ -5,7 +5,7 @@ use dioxus_free_icons::{Icon, icons::bs_icons::BsArrowUpRightSquare};
 
 use universal_inbox::{HasHtmlUrl, third_party::integrations::slack::SlackImDetails};
 
-use crate::components::{integrations::slack::SlackTeamDisplay, markdown::SlackMarkdown};
+use crate::components::{integrations::slack::SlackTeamDisplay, markdown::Markdown};
 
 #[component]
 pub fn SlackImPreview(
@@ -31,7 +31,7 @@ pub fn SlackImPreview(
                     class: "flex items-center",
                     href: "{slack_im().get_html_url()}",
                     target: "_blank",
-                    SlackMarkdown { text: "{title}" }
+                    Markdown { text: "{title}" }
                     Icon { class: "h-5 w-5 min-w-5 text-base-content/50 p-1", icon: BsArrowUpRightSquare }
                 }
             }

--- a/web/src/components/integrations/slack/preview/message.rs
+++ b/web/src/components/integrations/slack/preview/message.rs
@@ -10,7 +10,7 @@ use crate::components::{
     integrations::slack::{
         SlackTeamDisplay, get_sender_name_and_avatar, preview::reactions::SlackReactions,
     },
-    markdown::SlackMarkdown,
+    markdown::{Markdown, SlackHtml},
 };
 
 #[component]
@@ -37,7 +37,7 @@ pub fn SlackMessagePreview(
                     class: "flex items-center",
                     href: "{slack_message().url}",
                     target: "_blank",
-                    SlackMarkdown { text: "{title}" }
+                    Markdown { text: "{title}" }
                     Icon { class: "h-5 w-5 min-w-5 text-base-content/50 p-1", icon: BsArrowUpRightSquare }
                 }
             }
@@ -62,7 +62,7 @@ pub fn SlackMessagePreview(
 #[component]
 fn SlackMessageDisplay(slack_message: ReadSignal<SlackMessageDetails>) -> Element {
     let posted_at = slack_message().message.origin.ts.to_date_time_opt();
-    let text = slack_message().render_content();
+    let html = slack_message().render_content_as_html("text-primary", "text-warning", None);
     let (user_name, avatar_url) = get_sender_name_and_avatar(&slack_message().sender);
 
     rsx! {
@@ -84,7 +84,7 @@ fn SlackMessageDisplay(slack_message: ReadSignal<SlackMessageDetails>) -> Elemen
 
                 div {
                     class: "flex flex-col",
-                    SlackMarkdown { class: "prose prose-sm", text }
+                    SlackHtml { class: "prose prose-sm", html }
 
                     if let Some(reactions) = slack_message().message.content.reactions {
                         SlackReactions {

--- a/web/src/components/integrations/slack/preview/thread.rs
+++ b/web/src/components/integrations/slack/preview/thread.rs
@@ -11,7 +11,7 @@ use crate::components::{
     integrations::slack::{
         SlackTeamDisplay, get_sender_name_and_avatar, preview::reactions::SlackReactions,
     },
-    markdown::SlackMarkdown,
+    markdown::SlackHtml,
 };
 
 #[component]
@@ -149,7 +149,12 @@ fn SlackThreadMessageDisplay(
     let sender = message()
         .get_sender(&slack_thread().sender_profiles)
         .map(|sender| get_sender_name_and_avatar(&sender));
-    let text = message().render_content(slack_thread().references.clone(), true);
+    let html = message().render_content_as_html(
+        slack_thread().references.clone(),
+        "text-primary",
+        "text-warning",
+        slack_thread().user_slack_id.clone(),
+    );
 
     rsx! {
         div {
@@ -170,7 +175,7 @@ fn SlackThreadMessageDisplay(
 
             div {
                 class: "flex flex-col",
-                SlackMarkdown { class: "prose prose-sm", text }
+                SlackHtml { class: "prose prose-sm", html }
 
                 if let Some(reactions) = message().content.reactions {
                     SlackReactions {

--- a/web/src/components/markdown.rs
+++ b/web/src/components/markdown.rs
@@ -33,29 +33,14 @@ pub fn markdown_to_html(text: &str) -> String {
 }
 
 #[component]
-pub fn SlackMarkdown(text: String, class: Option<String>) -> Element {
+pub fn SlackHtml(html: String, class: Option<String>) -> Element {
     let class = class.unwrap_or("dark:prose-invert".to_string());
     rsx! {
-        p {
+        div {
             class: "w-full max-w-full {class}",
-            dangerous_inner_html: "{markdown_to_html_with_slack_references(&text)}"
+            dangerous_inner_html: "{html}"
         }
     }
-}
-
-pub fn markdown_to_html_with_slack_references(text: &str) -> String {
-    let html = markdown_to_html(text);
-    let slack_reference_re = Regex::new(r"@(@[^@]+)@").unwrap();
-    let html = slack_reference_re
-        .replace_all(&html, "<span class=\"text-primary\">$1</span>")
-        .to_string();
-    let slack_emoji_re = Regex::new(r#"<img src="https://emoji.slack-edge.com([^>]*)>"#).unwrap();
-    slack_emoji_re
-        .replace_all(
-            &html,
-            r#"<img class="slack-emoji" src="https://emoji.slack-edge.com$1>"#,
-        )
-        .to_string()
 }
 
 #[cfg(test)]
@@ -213,41 +198,5 @@ mod markdown_to_html_tests {
             assert!(result.contains(r#"target="_blank""#));
             assert!(result.contains(r#"rel="noopener noreferrer""#));
         }
-    }
-}
-
-#[cfg(test)]
-mod markdown_to_html_with_slack_references_tests {
-    use super::*;
-    use pretty_assertions::assert_eq;
-    use wasm_bindgen_test::*;
-
-    #[wasm_bindgen_test]
-    fn test_markdown_to_html_with_user_slack_reference() {
-        assert_eq!(
-            markdown_to_html_with_slack_references("@@user@"),
-            r#"<p><span class="text-primary">@user</span></p>
-"#
-            .to_string()
-        );
-    }
-
-    #[wasm_bindgen_test]
-    fn test_markdown_to_html_with_emoji_slack_reference() {
-        assert_eq!(
-            markdown_to_html_with_slack_references(
-                "![:custom_emoji:](https://emoji.slack-edge.com/custom_emoji.png)"
-            ),
-            r#"<p><img class="slack-emoji" src="https://emoji.slack-edge.com/custom_emoji.png" alt=":custom_emoji:" /></p>
-"#
-                .to_string()
-        );
-    }
-
-    #[wasm_bindgen_test]
-    fn test_markdown_to_html_with_slack_references_link_has_target_blank() {
-        let result = markdown_to_html_with_slack_references("[Link](https://example.com)");
-        assert!(result.contains(r#"target="_blank""#));
-        assert!(result.contains(r#"rel="noopener noreferrer""#));
     }
 }


### PR DESCRIPTION
## Summary
- Replace the Markdown→comrak→regex pipeline with direct HTML rendering from `slack-blocks-render` v0.5.0 for Slack message previews
- Upgrade `slack-morphism` to 2.20.0
- Add configurable mention highlighting: current user's mentions rendered in warning color, other mentions in primary color
- Populate `usergroup_ids_to_highlight` during reference resolution by checking usergroup membership via cached API calls

## Test plan
- [x] All 280 tests pass (root + API crates)
- [x] Web crate compiles for WASM target
- [ ] Visual verification of Slack thread rendering in preview pane
- [ ] Verify custom emoji display at correct size
- [ ] Verify long lines wrap in preformatted blocks
- [ ] Verify mention highlighting (current user vs others)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/universal-inbox/universal-inbox/pull/156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slack message content can now be rendered as HTML for richer, more accurate formatting.
  * Slack usergroups that include the current user are highlighted in message references.

* **Improvements**
  * Slack previews and threads use the new HTML rendering for consistent display.
  * Slack emoji sizing/styling improved for clearer inline display.
  * Normalized Slack link rendering to ensure consistent link targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->