### PR TITLE
feat: Configurable emoji reaction on Slack task completion

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           enable-cache: "true"
       - name: Build documentation
-        run: devbox run -- just build
+        run: devbox run -- just doc build
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/api/src/commands/generate.rs
+++ b/api/src/commands/generate.rs
@@ -370,6 +370,7 @@ async fn generate_slack_notifications_and_tasks(
                 sync_enabled: true,
                 reaction_name: SlackReactionName("eyes".to_string()),
                 sync_type: SlackSyncType::AsTasks(SlackSyncTaskConfig::default()),
+                completion_reaction_name: None,
             },
             message_config: SlackMessageConfig {
                 sync_enabled: true,

--- a/api/src/integrations/slack.rs
+++ b/api/src/integrations/slack.rs
@@ -954,6 +954,28 @@ impl SlackService {
         Ok(())
     }
 
+    async fn get_completion_reaction_name(
+        &self,
+        executor: &mut Transaction<'_, Postgres>,
+        integration_connection_id: IntegrationConnectionId,
+    ) -> Result<Option<SlackReactionName>, UniversalInboxError> {
+        let integration_connection = self
+            .integration_connection_service
+            .read()
+            .await
+            .get_integration_connection(executor, integration_connection_id)
+            .await?;
+        let Some(integration_connection) = integration_connection else {
+            return Ok(None);
+        };
+        match integration_connection.provider {
+            IntegrationProvider::Slack { config, .. } => {
+                Ok(config.reaction_config.completion_reaction_name)
+            }
+            _ => Ok(None),
+        }
+    }
+
     async fn add_slack_reaction(
         &self,
         executor: &mut Transaction<'_, Postgres>,
@@ -1780,7 +1802,22 @@ impl ThirdPartyTaskService<SlackReaction> for SlackService {
             &slack_reaction.name,
             user_id,
         )
-        .await
+        .await?;
+
+        if let Some(completion_reaction_name) = self
+            .get_completion_reaction_name(executor, third_party_item.integration_connection_id)
+            .await?
+        {
+            self.add_slack_reaction(
+                executor,
+                &slack_reaction.item,
+                &completion_reaction_name,
+                user_id,
+            )
+            .await?;
+        }
+
+        Ok(())
     }
 
     #[allow(clippy::blocks_in_conditions)]
@@ -1806,6 +1843,19 @@ impl ThirdPartyTaskService<SlackReaction> for SlackService {
                 third_party_item.kind()
             )));
         };
+
+        if let Some(completion_reaction_name) = self
+            .get_completion_reaction_name(executor, third_party_item.integration_connection_id)
+            .await?
+        {
+            self.delete_slack_reaction(
+                executor,
+                &slack_reaction.item,
+                &completion_reaction_name,
+                user_id,
+            )
+            .await?;
+        }
 
         self.add_slack_reaction(
             executor,

--- a/api/tests/api/test_slack_tasks.rs
+++ b/api/tests/api/test_slack_tasks.rs
@@ -9,7 +9,10 @@ use uuid::Uuid;
 use universal_inbox::{
     integration_connection::{
         config::IntegrationConnectionConfig,
-        integrations::{slack::SlackConfig, todoist::TodoistConfig},
+        integrations::{
+            slack::{SlackConfig, SlackReactionConfig},
+            todoist::TodoistConfig,
+        },
     },
     notification::{NotificationSourceKind, NotificationStatus},
     task::{Task, TaskCreationResult, TaskSourceKind, TaskStatus, service::TaskPatch},
@@ -480,4 +483,167 @@ Here is a [link](https://www.universal-inbox.com/)@@john.doe@@@admins@#universal
             ..exiting_task
         })
     );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_patch_slack_task_status_as_done_with_completion_reaction(
+    settings: Settings,
+    #[future] authenticated_app: AuthenticatedApp,
+    slack_push_reaction_added_event: Box<SlackPushEvent>,
+    slack_reacted_message: Box<SlackReactionItem>,
+    todoist_item: Box<TodoistItem>,
+    sync_todoist_projects_response: TodoistSyncResponse,
+    nango_slack_connection: Box<NangoConnection>,
+    nango_todoist_connection: Box<NangoConnection>,
+) {
+    let app = authenticated_app.await;
+    let slack_config = SlackConfig {
+        reaction_config: SlackReactionConfig {
+            completion_reaction_name: Some(SlackReactionName("done".to_string())),
+            ..SlackConfig::enabled_as_tasks().reaction_config
+        },
+        ..SlackConfig::enabled_as_tasks()
+    };
+    let integration_connection = create_and_mock_integration_connection(
+        &app.app,
+        app.user.id,
+        &settings.oauth2.nango_secret_key,
+        IntegrationConnectionConfig::Slack(slack_config),
+        &settings,
+        nango_slack_connection,
+        None,
+        None,
+    )
+    .await;
+    create_and_mock_integration_connection(
+        &app.app,
+        app.user.id,
+        &settings.oauth2.nango_secret_key,
+        IntegrationConnectionConfig::Todoist(TodoistConfig::enabled()),
+        &settings,
+        nango_todoist_connection,
+        None,
+        None,
+    )
+    .await;
+
+    mock_todoist_sync_resources_service(
+        &app.app.todoist_mock_server,
+        "projects",
+        &sync_todoist_projects_response,
+        None,
+    )
+    .await;
+
+    mock_todoist_item_add_service(
+        &app.app.todoist_mock_server,
+        &todoist_item.id,
+        "[📥  Universal Inbox new release 📥...](https://example.com/)".to_string(),
+        Some(
+            r#"📥  *Universal Inbox new release* 📥
+- list 1
+- list 2
+
+1. number 1
+1. number 2
+
+> quote
+
+
+```
+$ echo Hello world
+```
+\
+_Some_ `formatted` ~text~.\
+\
+Here is a [link](https://www.universal-inbox.com/)@@john.doe@@@admins@#universal-inbox
+👋![:unknown2:](https://emoji.com/unknown2.png)"#
+                .to_string(),
+        ),
+        Some(todoist_item.project_id.clone()),
+        None,
+        TodoistItemPriority::P1,
+    )
+    .await;
+    mock_todoist_get_item_service(
+        &app.app.todoist_mock_server,
+        Box::new(*todoist_item.clone()),
+    )
+    .await;
+
+    let SlackPushEvent::EventCallback(SlackPushEventCallback {
+        event:
+            SlackEventCallbackBody::ReactionAdded(SlackReactionAddedEvent {
+                item:
+                    SlackReactionsItem::Message(SlackHistoryMessage {
+                        origin: SlackMessageOrigin { ts: source_id, .. },
+                        ..
+                    }),
+                ..
+            }),
+        ..
+    }) = *slack_push_reaction_added_event
+    else {
+        unreachable!("Unexpected event type");
+    };
+    let creation: Box<ThirdPartyItemCreationResult> = create_resource(
+        &app.client,
+        &app.app.api_address,
+        "third_party/task/items",
+        Box::new(ThirdPartyItem {
+            id: Uuid::new_v4().into(),
+            source_id: source_id.to_string(),
+            created_at: Utc::now().with_nanosecond(0).unwrap(),
+            updated_at: Utc::now().with_nanosecond(0).unwrap(),
+            user_id: app.user.id,
+            data: ThirdPartyItemData::SlackReaction(Box::new(SlackReaction {
+                name: SlackReactionName("eyes".to_string()),
+                state: SlackReactionState::ReactionAdded,
+                created_at: Utc::now().with_nanosecond(0).unwrap(),
+                item: *slack_reacted_message,
+            })),
+            integration_connection_id: integration_connection.id,
+            source_item: None,
+        }),
+    )
+    .await;
+
+    let exiting_task = creation.task.as_ref().unwrap().clone();
+    assert_eq!(exiting_task.status, TaskStatus::Active);
+
+    let _todoist_mock = mock_todoist_complete_item_service(
+        &app.app.todoist_mock_server,
+        &exiting_task.sink_item.as_ref().unwrap().source_id,
+    )
+    .await;
+    let _slack_reaction_remove_mock = mock_slack_reactions_remove(
+        &app.app.slack_mock_server,
+        "C05XXX",
+        "1707686216.825719",
+        "eyes",
+    )
+    .await;
+    let _slack_reaction_add_mock = mock_slack_reactions_add(
+        &app.app.slack_mock_server,
+        "C05XXX",
+        "1707686216.825719",
+        "done",
+    )
+    .await;
+
+    let patched_task: Box<Task> = patch_resource(
+        &app.client,
+        &app.app.api_address,
+        "tasks",
+        exiting_task.id.into(),
+        &TaskPatch {
+            status: Some(TaskStatus::Done),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    assert!(patched_task.completed_at.is_some());
+    assert_eq!(patched_task.status, TaskStatus::Done);
 }

--- a/api/tests/api/test_slack_webhook_star_reaction.rs
+++ b/api/tests/api/test_slack_webhook_star_reaction.rs
@@ -167,6 +167,7 @@ async fn test_receive_reaction_event_for_different_reaction(
                 sync_enabled: true,
                 reaction_name: SlackReactionName("bookmark".to_string()), // slack_push_reaction_added_event uses "eyes" reaction
                 sync_type: SlackSyncType::AsNotifications,
+                completion_reaction_name: None,
             },
             ..SlackConfig::default()
         }),

--- a/src/integration_connection/integrations/slack.rs
+++ b/src/integration_connection/integrations/slack.rs
@@ -29,6 +29,8 @@ pub struct SlackReactionConfig {
     pub sync_enabled: bool,
     pub reaction_name: SlackReactionName,
     pub sync_type: SlackSyncType,
+    #[serde(default)]
+    pub completion_reaction_name: Option<SlackReactionName>,
 }
 
 #[derive(Deserialize, Serialize, PartialEq, Eq, Debug, Clone)]
@@ -56,6 +58,7 @@ impl Default for SlackConfig {
                 sync_enabled: false,
                 reaction_name: SlackReactionName("eyes".to_string()),
                 sync_type: SlackSyncType::AsNotifications,
+                completion_reaction_name: None,
             },
             message_config: SlackMessageConfig {
                 sync_enabled: false,
@@ -73,6 +76,7 @@ impl SlackConfig {
                 sync_enabled: true,
                 reaction_name: SlackReactionName("eyes".to_string()),
                 sync_type: SlackSyncType::AsNotifications,
+                completion_reaction_name: None,
             },
             message_config: SlackMessageConfig {
                 sync_enabled: true,
@@ -88,6 +92,7 @@ impl SlackConfig {
                 sync_enabled: true,
                 reaction_name: SlackReactionName("eyes".to_string()),
                 sync_type: SlackSyncType::AsTasks(SlackSyncTaskConfig::default()),
+                completion_reaction_name: None,
             },
             message_config: SlackMessageConfig {
                 sync_enabled: false,
@@ -103,6 +108,7 @@ impl SlackConfig {
                 sync_enabled: false,
                 reaction_name: SlackReactionName("eyes".to_string()),
                 sync_type: SlackSyncType::AsNotifications,
+                completion_reaction_name: None,
             },
             message_config: SlackMessageConfig {
                 sync_enabled: false,

--- a/web/src/components/integrations/slack/config.rs
+++ b/web/src/components/integrations/slack/config.rs
@@ -135,12 +135,18 @@ fn SlackReactionConfiguration(
     on_config_change: EventHandler<IntegrationConnectionConfig>,
 ) -> Element {
     let mut default_emoji = use_signal(|| "eyes".to_string());
+    let mut default_completion_emoji: Signal<Option<String>> = use_signal(|| None);
     let mut default_priority = use_signal(|| Some(TaskPriority::P4));
     let mut default_due_at: Signal<Option<PresetDueDate>> = use_signal(|| None);
     let mut default_project: Signal<Option<ProjectSummary>> = use_signal(|| None);
     let mut task_config_enabled = use_signal(|| false);
     use_memo(move || {
         *default_emoji.write() = config().reaction_config.reaction_name.0.clone();
+        *default_completion_emoji.write() = config()
+            .reaction_config
+            .completion_reaction_name
+            .as_ref()
+            .map(|name| name.0.clone());
         if let SlackSyncType::AsTasks(config) = config().reaction_config.sync_type {
             *default_priority.write() = Some(config.default_priority);
             default_due_at.write().clone_from(&config.default_due_at);
@@ -152,6 +158,13 @@ fn SlackReactionConfiguration(
     });
     let collapse_style = use_memo(move || {
         if task_config_enabled() {
+            ""
+        } else {
+            "hidden overflow-hidden"
+        }
+    });
+    let completion_reaction_collapse_style = use_memo(move || {
+        if config().reaction_config.completion_reaction_name.is_some() {
             ""
         } else {
             "hidden overflow-hidden"
@@ -224,6 +237,83 @@ fn SlackReactionConfiguration(
                         ..config()
                     }));
                 },
+            }
+        }
+
+        div {
+            class: "flex flex-col gap-2 overflow-visible",
+
+            div {
+                class: "flex items-center gap-2",
+                label {
+                    class: "label-text cursor-pointer grow text-sm text-base-content",
+                    "Set an emoji reaction when the task is completed"
+                }
+                div {
+                    class: "relative inline-block",
+                    input {
+                        r#type: "checkbox",
+                        class: "switch switch-primary switch-outline peer",
+                        disabled: !config().reaction_config.sync_enabled,
+                        oninput: move |event| {
+                            let completion_reaction_name = if event.value() == "true" {
+                                Some(SlackReactionName("white_check_mark".to_string()))
+                            } else {
+                                None
+                            };
+                            on_config_change.call(IntegrationConnectionConfig::Slack(SlackConfig {
+                                reaction_config: SlackReactionConfig {
+                                    completion_reaction_name,
+                                    ..config().reaction_config
+                                },
+                                ..config()
+                            }))
+                        },
+                        checked: config().reaction_config.completion_reaction_name.is_some()
+                    }
+                    span {
+                        class: "icon-[tabler--check] text-primary absolute start-1 top-1 hidden size-4 peer-checked:block"
+                    }
+                    span {
+                        class: "icon-[tabler--x] text-neutral absolute end-1 top-1 block size-4 peer-checked:hidden"
+                    }
+                }
+            }
+
+            div {
+                class: "collapse transition-[height] duration-300 {completion_reaction_collapse_style} pb-0 pr-0 flex flex-col gap-2",
+
+                div {
+                    class: "flex items-center gap-2",
+                    label {
+                        class: "label-text cursor-pointer grow text-sm text-base-content",
+                        "Emoji reaction to set on completion"
+                    }
+                    FloatingLabelInputSearchSelect::<SlackEmojiSuggestion> {
+                        name: "completion-reaction-name-input".to_string(),
+                        class: "max-w-xs",
+                        disabled: !config().reaction_config.sync_enabled,
+                        data_select: json!({
+                            "value": default_completion_emoji().unwrap_or_default(),
+                            "apiUrl": format!("{api_base_url}integration-connections/{}/slack/emojis/search", connection_id()),
+                            "apiSearchQueryKey": "matches",
+                            "apiFieldsMap": {
+                                "id": "name",
+                                "val": "name",
+                                "title": "display_name"
+                            }
+                        }),
+                        on_select: move |emoji: Option<SlackEmojiSuggestion>| {
+                            on_config_change.call(IntegrationConnectionConfig::Slack(SlackConfig {
+                                reaction_config: SlackReactionConfig {
+                                    completion_reaction_name: emoji.map(|e| SlackReactionName(e.name)),
+                                    ..config().reaction_config
+                                },
+                                ..config()
+                            }));
+                        },
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

- Adds an optional completion emoji (e.g. `:done:`) that gets set on a Slack message when its synced task is marked as done.
- Previously, completing a Slack reaction task only removed the trigger reaction — nothing visible signalled that the item had been handled. Now users can configure a distinct emoji so the message still shows a clear "done" marker to themselves and teammates.
- On un-completion the flow reverses: the completion emoji is removed and the trigger reaction is re-added, mirroring the existing symmetry.

## Changes

- `SlackReactionConfig` gains `completion_reaction_name: Option<SlackReactionName>` with `#[serde(default)]` for backward compat (no DB migration needed).
- `SlackService::complete_task` / `uncomplete_task` load the current config via a new `get_completion_reaction_name` helper and call the existing `add_slack_reaction` / `delete_slack_reaction` helpers for the completion emoji.
- The Slack reaction configuration panel gets a new toggle ("Set an emoji reaction when the task is completed") + a conditional searchable emoji picker, reusing the existing `FloatingLabelInputSearchSelect<SlackEmojiSuggestion>` component and the `/slack/emojis/search` API.

## Test plan

- [ ] `cargo test -p universal-inbox-api --test api test_patch_slack_task_status_as_done_with_completion_reaction` — new integration test verifies both `reactions.remove` (trigger) and `reactions.add` (completion) are called on task completion.
- [ ] `cargo test -p universal-inbox-api` — existing Slack task tests still pass (no regression).
- [ ] Manual smoke test against a real Slack workspace:
  - [ ] Settings → Slack: enable reaction sync, set trigger `:eyes:`, toggle "Set emoji on completion" on, pick `:done:`.
  - [ ] React to a message with `:eyes:` → task appears.
  - [ ] Mark task done → `:eyes:` removed, `:done:` added on the Slack message.
  - [ ] Un-complete the task → `:done:` removed, `:eyes:` re-added.
  - [ ] Disable the completion toggle → completion only removes `:eyes:` (prior behavior).
- [ ] Backward compat: load an existing integration connection created before this change — deserialises with `completion_reaction_name: None` and behaves as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/universal-inbox/universal-inbox/pull/157" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Configure a distinct Slack emoji reaction to display when tasks are completed
  * Slack messages automatically show the completion emoji when task status is marked as done
  * Completion emoji is removed when tasks are reverted to incomplete status

* **Tests**
  * Added test coverage for task completion with custom emoji reactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->