### PR TITLE
fix: Guard Slack bridge action status transitions

### DIFF
--- a/api/src/repository/slack_bridge.rs
+++ b/api/src/repository/slack_bridge.rs
@@ -201,6 +201,7 @@ impl SlackBridgeRepository for Repository {
                     completed_at = NOW(),
                     updated_at = NOW()
                 WHERE id = $1 AND user_id = $2
+                  AND status IN ('Pending', 'Failed')
                 RETURNING *
             "#,
         )
@@ -235,6 +236,7 @@ impl SlackBridgeRepository for Repository {
                     retry_count = retry_count + 1,
                     updated_at = NOW()
                 WHERE id = $1 AND user_id = $4
+                  AND status IN ('Pending', 'Failed')
                 RETURNING *
             "#,
         )

--- a/api/src/universal_inbox/slack_bridge/service.rs
+++ b/api/src/universal_inbox/slack_bridge/service.rs
@@ -148,9 +148,17 @@ impl SlackBridgeService {
         action_id: SlackBridgePendingActionId,
         user_id: UserId,
     ) -> Result<Option<SlackBridgePendingAction>, UniversalInboxError> {
-        self.repository
+        let result = self
+            .repository
             .mark_action_completed(executor, action_id, user_id)
-            .await
+            .await?;
+        if result.is_none() {
+            tracing::warn!(
+                %action_id, %user_id,
+                "Slack bridge action not marked as completed: action missing or in terminal state"
+            );
+        }
+        Ok(result)
     }
 
     #[tracing::instrument(
@@ -166,9 +174,17 @@ impl SlackBridgeService {
         user_id: UserId,
         error: &str,
     ) -> Result<Option<SlackBridgePendingAction>, UniversalInboxError> {
-        self.repository
+        let result = self
+            .repository
             .mark_action_failed(executor, action_id, user_id, error)
-            .await
+            .await?;
+        if result.is_none() {
+            tracing::warn!(
+                %action_id, %user_id,
+                "Slack bridge action not marked as failed: action missing or in terminal state"
+            );
+        }
+        Ok(result)
     }
 
     #[tracing::instrument(

--- a/api/tests/api/main.rs
+++ b/api/tests/api/main.rs
@@ -16,6 +16,7 @@ mod test_linear_tasks;
 mod test_mcp;
 mod test_misc;
 mod test_notifications;
+mod test_slack_bridge;
 mod test_slack_notifications;
 mod test_slack_tasks;
 mod test_slack_webhook;

--- a/api/tests/api/test_slack_bridge.rs
+++ b/api/tests/api/test_slack_bridge.rs
@@ -1,0 +1,184 @@
+use chrono::Utc;
+use pretty_assertions::assert_eq;
+use rstest::*;
+use serde_json::json;
+use slack_morphism::prelude::*;
+use sqlx::FromRow;
+use uuid::Uuid;
+
+use universal_inbox::slack_bridge::{
+    SlackBridgeActionStatus, SlackBridgeActionType, SlackBridgePendingAction,
+    SlackBridgePendingActionId,
+};
+use universal_inbox_api::repository::slack_bridge::SlackBridgeRepository;
+
+use crate::helpers::{
+    TestedApp,
+    auth::{AuthenticatedApp, authenticated_app},
+};
+
+#[derive(Debug, FromRow)]
+struct ActionState {
+    status: String,
+    retry_count: i32,
+    completed_at: Option<chrono::DateTime<Utc>>,
+    failure_message: Option<String>,
+}
+
+async fn read_action_state(app: &TestedApp, id: SlackBridgePendingActionId) -> ActionState {
+    sqlx::query_as::<_, ActionState>(
+        r#"
+            SELECT status, retry_count, completed_at, failure_message
+            FROM slack_bridge_pending_action
+            WHERE id = $1
+        "#,
+    )
+    .bind(id.0)
+    .fetch_one(&*app.repository.pool)
+    .await
+    .expect("Failed to read slack_bridge_pending_action state")
+}
+
+async fn seed_action(
+    app: &AuthenticatedApp,
+    status: SlackBridgeActionStatus,
+) -> SlackBridgePendingActionId {
+    let now = Utc::now();
+    let action = SlackBridgePendingAction {
+        id: Uuid::new_v4().into(),
+        user_id: app.user.id,
+        notification_id: None,
+        action_type: SlackBridgeActionType::MarkAsRead,
+        slack_team_id: SlackTeamId::new("T1234".to_string()),
+        slack_channel_id: SlackChannelId::new("C1234".to_string()),
+        slack_thread_ts: SlackTs::new("1700000000.000100".to_string()),
+        slack_last_message_ts: SlackTs::new("1700000000.000200".to_string()),
+        status,
+        failure_message: None,
+        retry_count: 0,
+        created_at: now,
+        updated_at: now,
+        completed_at: None,
+    };
+
+    let mut tx = app.app.repository.begin().await.unwrap();
+    let created = app
+        .app
+        .repository
+        .create_pending_action(&mut tx, &action)
+        .await
+        .expect("Failed to seed slack bridge pending action");
+    tx.commit().await.unwrap();
+    created.id
+}
+
+async fn post_complete(app: &AuthenticatedApp, id: SlackBridgePendingActionId) -> u16 {
+    app.client
+        .post(format!(
+            "{}slack-bridge/actions/{}/complete",
+            app.app.api_address, id.0
+        ))
+        .send()
+        .await
+        .unwrap()
+        .status()
+        .as_u16()
+}
+
+async fn post_fail(app: &AuthenticatedApp, id: SlackBridgePendingActionId, error: &str) -> u16 {
+    app.client
+        .post(format!(
+            "{}slack-bridge/actions/{}/fail",
+            app.app.api_address, id.0
+        ))
+        .json(&json!({ "error": error }))
+        .send()
+        .await
+        .unwrap()
+        .status()
+        .as_u16()
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_complete_pending_action_succeeds(#[future] authenticated_app: AuthenticatedApp) {
+    let app = authenticated_app.await;
+    let action_id = seed_action(&app, SlackBridgeActionStatus::Pending).await;
+
+    assert_eq!(post_complete(&app, action_id).await, 200);
+
+    let state = read_action_state(&app.app, action_id).await;
+    assert_eq!(state.status, "Completed");
+    assert!(state.completed_at.is_some());
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_complete_failed_action_succeeds(#[future] authenticated_app: AuthenticatedApp) {
+    let app = authenticated_app.await;
+    let action_id = seed_action(&app, SlackBridgeActionStatus::Failed).await;
+
+    assert_eq!(post_complete(&app, action_id).await, 200);
+
+    let state = read_action_state(&app.app, action_id).await;
+    assert_eq!(state.status, "Completed");
+    assert!(state.completed_at.is_some());
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_fail_after_complete_is_noop(#[future] authenticated_app: AuthenticatedApp) {
+    let app = authenticated_app.await;
+    let action_id = seed_action(&app, SlackBridgeActionStatus::Pending).await;
+
+    assert_eq!(post_complete(&app, action_id).await, 200);
+    let after_complete = read_action_state(&app.app, action_id).await;
+    assert_eq!(after_complete.status, "Completed");
+
+    // A stale failure report from the extension must not revert the action.
+    assert_eq!(post_fail(&app, action_id, "stale error").await, 200);
+
+    let state = read_action_state(&app.app, action_id).await;
+    assert_eq!(state.status, "Completed");
+    assert_eq!(state.retry_count, 0);
+    assert!(state.failure_message.is_none());
+    assert_eq!(state.completed_at, after_complete.completed_at);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_complete_after_permanently_failed_is_noop(
+    #[future] authenticated_app: AuthenticatedApp,
+) {
+    let app = authenticated_app.await;
+    let action_id = seed_action(&app, SlackBridgeActionStatus::PermanentlyFailed).await;
+
+    assert_eq!(post_complete(&app, action_id).await, 200);
+
+    let state = read_action_state(&app.app, action_id).await;
+    assert_eq!(state.status, "PermanentlyFailed");
+    assert!(state.completed_at.is_none());
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_fail_transitions_to_permanently_failed_after_max_retries(
+    #[future] authenticated_app: AuthenticatedApp,
+) {
+    let app = authenticated_app.await;
+    let action_id = seed_action(&app, SlackBridgeActionStatus::Pending).await;
+
+    // MAX_RETRIES = 5: first 4 failures stay in Failed, 5th transitions to PermanentlyFailed.
+    for _ in 0..4 {
+        assert_eq!(post_fail(&app, action_id, "transient").await, 200);
+    }
+    let state = read_action_state(&app.app, action_id).await;
+    assert_eq!(state.status, "Failed");
+    assert_eq!(state.retry_count, 4);
+
+    assert_eq!(post_fail(&app, action_id, "terminal").await, 200);
+    let state = read_action_state(&app.app, action_id).await;
+    assert_eq!(state.status, "PermanentlyFailed");
+    assert_eq!(state.retry_count, 5);
+    assert_eq!(state.failure_message.as_deref(), Some("terminal"));
+}


### PR DESCRIPTION
## Summary

- Add `AND status IN ('Pending', 'Failed')` to the `UPDATE` clauses of `mark_action_completed` and `mark_action_failed` in `api/src/repository/slack_bridge.rs`, so stale extension reports cannot flip a `Completed` action back to `Failed` and have it re-picked up by `get_actionable_actions` (which would re-execute the Slack "mark as read" or unsubscribe).
- Log a `tracing::warn!` in `complete_action` / `fail_action` when the repository returns `None` on an invalid transition — visible in observability, HTTP response shape unchanged (still 200 OK) so the browser extension doesn't treat stale reports as hard errors.
- Encode the state machine (`Pending`/`Failed` → `Completed`; `Pending`/`Failed` → `Failed`; `Failed` → `PermanentlyFailed` after `MAX_RETRIES`) with five integration tests, including the primary regression test `test_fail_after_complete_is_noop`.

## State machine

```
Pending  ─success─▶ Completed
Pending  ─error──▶ Failed
Failed   ─success─▶ Completed           (retry success)
Failed   ─error──▶ Failed               (retry_count++)
Failed   ─error──▶ PermanentlyFailed    (retry_count+1 >= MAX_RETRIES = 5)
Completed, PermanentlyFailed            (terminal)
```

## Test plan

- [x] `cargo check -p universal-inbox-api --tests` passes
- [x] `just test test_slack_bridge` — all 5 tests pass
  - `test_complete_pending_action_succeeds`
  - `test_complete_failed_action_succeeds`
  - `test_fail_after_complete_is_noop` (regression)
  - `test_complete_after_permanently_failed_is_noop`
  - `test_fail_transitions_to_permanently_failed_after_max_retries`
- [ ] Full api test suite (`just test`) — reviewer to confirm on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/universal-inbox/universal-inbox/pull/158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Slack bridge actions now properly prevent modifications to completed or permanently failed actions, ensuring status transitions are enforced correctly.
  * Improved error handling with warning logs when action state updates fail or actions are in terminal states.

* **Tests**
  * Added comprehensive integration tests for Slack bridge action state management, including idempotency and retry behavior validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->