### PR TITLE
fix: Skip Google Drive files that 404 on comments list

### DIFF
--- a/api/src/integrations/google_drive.rs
+++ b/api/src/integrations/google_drive.rs
@@ -49,7 +49,7 @@ use crate::{
         UniversalInboxError, integration_connection::service::IntegrationConnectionService,
         notification::service::NotificationService,
     },
-    utils::api::ApiClient,
+    utils::api::{ApiClient, ApiClientError},
 };
 
 #[derive(Clone)]
@@ -342,20 +342,35 @@ impl GoogleDriveService {
                     .map(|token| format!("&pageToken={token}"))
                     .unwrap_or_default()
             );
-            let comment_list: GoogleDriveCommentList = self
+            match self
                 .build_google_drive_client(access_token)?
-                .get(&comments_url)
+                .get::<GoogleDriveCommentList, _>(&comments_url)
                 .await
-                .context("Failed to fetch Google Drive comments")?;
+            {
+                Ok(comment_list) => {
+                    if let Some(mut new_comments) = comment_list.comments {
+                        comments.append(&mut new_comments);
+                    }
 
-            if let Some(mut new_comments) = comment_list.comments {
-                comments.append(&mut new_comments);
+                    if comment_list.next_page_token.is_none() {
+                        break;
+                    }
+                    page_token = comment_list.next_page_token;
+                }
+                Err(ApiClientError::NetworkError(err))
+                    if err.status() == Some(reqwest_middleware::reqwest::StatusCode::NOT_FOUND) =>
+                {
+                    debug!(
+                        "Google Drive file {file_id} does not support comments (404). Skipping."
+                    );
+                    break;
+                }
+                Err(err) => {
+                    return Err(anyhow!(err)
+                        .context("Failed to fetch Google Drive comments")
+                        .into());
+                }
             }
-
-            if comment_list.next_page_token.is_none() {
-                break;
-            }
-            page_token = comment_list.next_page_token;
         }
 
         Ok(comments)

--- a/api/tests/api/helpers/notification/google_drive.rs
+++ b/api/tests/api/helpers/notification/google_drive.rs
@@ -147,6 +147,21 @@ pub async fn mock_google_drive_comments_list_service(
         .await;
 }
 
+pub async fn mock_google_drive_comments_list_404_service(
+    google_drive_mock_server: &MockServer,
+    file_id: &str,
+) {
+    Mock::given(method("GET"))
+        .and(path(format!("/files/{}/comments", file_id)))
+        .and(header(
+            "authorization",
+            "Bearer google_drive_test_access_token",
+        ))
+        .respond_with(ResponseTemplate::new(404).insert_header("content-type", "application/json"))
+        .mount(google_drive_mock_server)
+        .await;
+}
+
 #[fixture]
 pub fn google_drive_files_list() -> GoogleDriveFileList {
     load_json_fixture_file("google_drive/google_drive_files_list.json")

--- a/api/tests/api/test_sync_google_drive_comments.rs
+++ b/api/tests/api/test_sync_google_drive_comments.rs
@@ -49,8 +49,9 @@ use crate::helpers::{
         google_drive::{
             assert_sync_notifications, create_notification_from_google_drive_comment,
             google_drive_comment_123, google_drive_comment_456, google_drive_comments_list,
-            google_drive_files_list, mock_google_drive_comments_list_service,
-            mock_google_drive_files_list_service, mock_google_drive_get_user_info_service,
+            google_drive_files_list, mock_google_drive_comments_list_404_service,
+            mock_google_drive_comments_list_service, mock_google_drive_files_list_service,
+            mock_google_drive_get_user_info_service,
         },
         sync_notifications, update_notification,
     },
@@ -477,4 +478,106 @@ async fn test_sync_notifications_of_unsubscribed_notification_with_new_messages(
         updated_notification.status,
         expected_notification_status_after_sync
     );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_sync_notifications_skips_files_returning_404_on_comments(
+    settings: Settings,
+    #[future] authenticated_app: AuthenticatedApp,
+    google_drive_comments_list: GoogleDriveCommentList,
+    google_drive_files_list: GoogleDriveFileList,
+    nango_google_drive_connection: Box<NangoConnection>,
+) {
+    // Some Google Drive file types (Google My Maps, Sites, Forms, Scripts, folders, shortcuts...)
+    // do not expose a `/comments` sub-resource and Drive responds 404 when we try to list their
+    // comments. A single 404 must not abort the entire sync — comments on commentable files
+    // must still be synced.
+    let app = authenticated_app.await;
+    let user_email_address = EmailAddress::from_str("jane.doe@example.com").unwrap();
+    let google_drive_config = GoogleDriveConfig::enabled();
+
+    let google_drive_about_response = GoogleDriveAboutResponse {
+        user: GoogleDriveUserInfo {
+            email_address: user_email_address.to_string(),
+            display_name: "Jane Doe".to_string(),
+        },
+    };
+    let _google_drive_get_user_info_mock = mock_google_drive_get_user_info_service(
+        &app.app.google_drive_mock_server,
+        &google_drive_about_response,
+    )
+    .await;
+
+    let google_drive_integration_connection = create_and_mock_integration_connection(
+        &app.app,
+        app.user.id,
+        &settings.oauth2.nango_secret_key,
+        IntegrationConnectionConfig::GoogleDrive(google_drive_config.clone()),
+        &settings,
+        nango_google_drive_connection,
+        None,
+        None,
+    )
+    .await;
+
+    let google_drive_files_list = GoogleDriveFileList {
+        next_page_token: None,
+        ..google_drive_files_list
+    };
+    let _google_drive_files_list_mock = mock_google_drive_files_list_service(
+        &app.app.google_drive_mock_server,
+        None,
+        settings
+            .integrations
+            .get("google_drive")
+            .unwrap()
+            .page_size
+            .unwrap(),
+        google_drive_integration_connection.created_at,
+        &google_drive_files_list,
+    )
+    .await;
+
+    // First file: returns comments normally
+    let google_drive_comments_list = GoogleDriveCommentList {
+        next_page_token: None,
+        ..google_drive_comments_list
+    };
+    let _google_drive_comments_list_mock = mock_google_drive_comments_list_service(
+        &app.app.google_drive_mock_server,
+        None,
+        settings
+            .integrations
+            .get("google_drive")
+            .unwrap()
+            .page_size
+            .unwrap(),
+        &google_drive_files_list.files.as_ref().unwrap()[0].id,
+        &google_drive_comments_list,
+    )
+    .await;
+
+    // Second file: 404 (simulating a non-commentable file type like Google My Maps)
+    let _google_drive_comments_list_404_mock = mock_google_drive_comments_list_404_service(
+        &app.app.google_drive_mock_server,
+        &google_drive_files_list.files.as_ref().unwrap()[1].id,
+    )
+    .await;
+
+    let notifications: Vec<Notification> = sync_notifications(
+        &app.client,
+        &app.app.api_address,
+        Some(NotificationSourceKind::GoogleDrive),
+        false,
+    )
+    .await;
+
+    // The sync must succeed and return the comment_123 notification from the commentable
+    // file (comment_456 would be created as Deleted because the last reply is from the user,
+    // and Deleted notifications are filtered from the sync response). The 404 from the other
+    // file must not abort the sync.
+    assert_eq!(notifications.len(), 1);
+    assert_eq!(notifications[0].kind, NotificationSourceKind::GoogleDrive);
+    assert_eq!(notifications[0].status, NotificationStatus::Unread);
 }


### PR DESCRIPTION
## Summary

- A single 404 from Google Drive's `comments.list` endpoint was aborting the **entire** sync for a user via `.error_for_status()` + `.await?`
- Root cause: `files.list` has no mime-type filter, so non-commentable file types (Google My Maps, Sites, Forms, Scripts, folders, shortcuts...) get fed into `fetch_comments_for_file`, which returns 404
- Fix: handle 404 the same way Todoist (`todoist.rs:324`) and GitHub (`github/mod.rs:238,266`) already do — log at debug and skip the file

## Verification

Reproduced with the failing file `1nh_jR073YQFIYoMudLxSZXoTLUo` (a Google My Maps document, mimeType `application/vnd.google-apps.map`). Drive returns 404 on its `/comments` regardless of URL shape or auth — the file simply doesn't expose that sub-resource.

## Test plan

- [x] `cd api && just check` — clippy + type check, no warnings
- [x] `cd api && just test test_sync_google_drive_comments` — 5/5 pass (4 existing + 1 new regression test)
- [x] New test `test_sync_notifications_skips_files_returning_404_on_comments` mocks a 2-file sync where one file 404s and asserts sync completes with comments from the other file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/universal-inbox/universal-inbox/pull/159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google Drive notification sync robustness—the system now gracefully skips files that don't support comments instead of failing the entire sync operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->