### PR TITLE
feat: Hide quoted content in Gmail email previews

### DIFF
--- a/api/tests/api/fixtures/google_mail_thread_get_123.json
+++ b/api/tests/api/fixtures/google_mail_thread_get_123.json
@@ -8,7 +8,7 @@
       "labelIds": ["STARRED", "INBOX", "UNREAD"],
       "snippet": "test",
       "payload": {
-        "mimeType": "multipart/alternative",
+        "mimeType": "text/html",
         "headers": [
           {
             "name": "Date",
@@ -26,7 +26,11 @@
             "name": "To",
             "value": "test@example.com"
           }
-        ]
+        ],
+        "body": {
+          "size": 722,
+          "data": "PGRpdiBkaXI9Imx0ciI-SGkgdGVhbSw8YnI-PGJyPkxvb2tzIGdvb2QgdG8gbWUsIHNoaXBwaW5nIHRvZGF5ITxicj48L2Rpdj48ZGl2IGNsYXNzPSJnbWFpbF9xdW90ZSBnbWFpbF9xdW90ZV9jb250YWluZXIiPjxkaXYgZGlyPSJsdHIiIGNsYXNzPSJnbWFpbF9hdHRyIj5PbiBTYXQsIFNlcCAxNiwgMjAyMyBhdCAyOjA1IFBNIEphbmUgU21pdGggJmx0O2phbmVAZXhhbXBsZS5jb20mZ3Q7IHdyb3RlOjxicj48L2Rpdj48YmxvY2txdW90ZSBjbGFzcz0iZ21haWxfcXVvdGUiIHN0eWxlPSJtYXJnaW46MHB4IDBweCAwcHggMC44ZXg7Ym9yZGVyLWxlZnQ6MXB4IHNvbGlkIHJnYigyMDQsMjA0LDIwNCk7cGFkZGluZy1sZWZ0OjFleCI-PGRpdiBkaXI9Imx0ciI-SGV5IHRlYW0sPGJyPjxicj5QbGVhc2UgcmV2aWV3IHRoZSBVbml2ZXJzYWwgSW5ib3ggcm9sbG91dCBwbGFuIGFuZCBjb25maXJtIHdlIGNhbiBzaGlwIGJ5IGVuZCBvZiB3ZWVrLjxicj48YnI-VGhhbmtzITxicj5KYW5lPGJyPjwvZGl2PjwvYmxvY2txdW90ZT48L2Rpdj4="
+        }
       },
       "sizeEstimate": 2222,
       "historyId": "111",

--- a/src/third_party/integrations/google_mail.rs
+++ b/src/third_party/integrations/google_mail.rs
@@ -289,7 +289,7 @@ impl GoogleMailMessagePayload {
 
     fn render_text_body_as_html(&self) -> Option<String> {
         self.decode_body_data()
-            .map(|body| body.replace("\r\n", "<br>").replace("\n", "<br>"))
+            .map(|body| wrap_plain_text_quotes_as_html(&body))
     }
 
     fn render_html_body(&self) -> Option<String> {
@@ -323,6 +323,43 @@ impl GoogleMailMessagePayload {
                 .find_map(|part| part.find_attachment_id_for_mime_type(mime_type))
         })
     }
+}
+
+fn wrap_plain_text_quotes_as_html(body: &str) -> String {
+    let normalized = body.replace("\r\n", "\n");
+    let mut out = String::with_capacity(normalized.len() + 32);
+    let mut in_quote = false;
+    for raw in normalized.split_inclusive('\n') {
+        let has_newline = raw.ends_with('\n');
+        let line = if has_newline {
+            &raw[..raw.len() - 1]
+        } else {
+            raw
+        };
+        let trimmed = line.trim_start();
+        let is_quote_line = trimmed.starts_with('>');
+        if is_quote_line && !in_quote {
+            out.push_str("<blockquote class=\"gmail_quote\">");
+            in_quote = true;
+        } else if !is_quote_line && in_quote {
+            out.push_str("</blockquote>");
+            in_quote = false;
+        }
+        if is_quote_line {
+            let after_gt = &trimmed[1..];
+            let content = after_gt.strip_prefix(' ').unwrap_or(after_gt);
+            out.push_str(content);
+        } else {
+            out.push_str(line);
+        }
+        if has_newline {
+            out.push_str("<br>");
+        }
+    }
+    if in_quote {
+        out.push_str("</blockquote>");
+    }
+    out
 }
 
 #[cfg(test)]
@@ -687,6 +724,67 @@ mod tests {
                 .render_content_as_html();
 
                 assert_eq!(content, "<p>this is an invitation</p>\n");
+            }
+        }
+
+        mod plain_text_quote_wrapping {
+            use super::*;
+            use pretty_assertions::assert_eq;
+
+            #[rstest]
+            fn test_no_quote_lines_preserves_existing_behavior() {
+                assert_eq!(
+                    wrap_plain_text_quotes_as_html("test message body\n"),
+                    "test message body<br>"
+                );
+            }
+
+            #[rstest]
+            fn test_crlf_line_endings_are_normalized() {
+                assert_eq!(
+                    wrap_plain_text_quotes_as_html("hello\r\nworld\r\n"),
+                    "hello<br>world<br>"
+                );
+            }
+
+            #[rstest]
+            fn test_single_quoted_block_is_wrapped() {
+                assert_eq!(
+                    wrap_plain_text_quotes_as_html("hi\n> quoted reply\n> more quoted\n"),
+                    "hi<br><blockquote class=\"gmail_quote\">quoted reply<br>more quoted<br></blockquote>"
+                );
+            }
+
+            #[rstest]
+            fn test_quote_without_space_after_marker() {
+                assert_eq!(
+                    wrap_plain_text_quotes_as_html(">quoted\n"),
+                    "<blockquote class=\"gmail_quote\">quoted<br></blockquote>"
+                );
+            }
+
+            #[rstest]
+            fn test_nested_quote_strips_only_one_level() {
+                assert_eq!(
+                    wrap_plain_text_quotes_as_html("> > double quoted\n"),
+                    "<blockquote class=\"gmail_quote\">> double quoted<br></blockquote>"
+                );
+            }
+
+            #[rstest]
+            fn test_quote_then_normal_text_closes_block() {
+                assert_eq!(
+                    wrap_plain_text_quotes_as_html("> quoted\nafter\n"),
+                    "<blockquote class=\"gmail_quote\">quoted<br></blockquote>after<br>"
+                );
+            }
+
+            #[rstest]
+            fn test_trailing_quote_without_newline_still_closes() {
+                assert_eq!(
+                    wrap_plain_text_quotes_as_html("hi\n> quoted"),
+                    "hi<br><blockquote class=\"gmail_quote\">quoted</blockquote>"
+                );
             }
         }
     }

--- a/web/src/components/integrations/google_mail/preview.rs
+++ b/web/src/components/integrations/google_mail/preview.rs
@@ -141,12 +141,16 @@ fn GoogleMailThreadMessage(message: ReadSignal<GoogleMailMessage>) -> Element {
         headers
             .push(rsx! { span { class: "text-neutral-content/75", "Date:" }, span { "{date}" } });
     }
-    let message_body = use_memo(move || {
-        ammonia::Builder::default()
+    let message_parts = use_memo(move || {
+        let sanitized = ammonia::Builder::default()
             .set_tag_attribute_value("a", "target", "_blank")
+            .add_tag_attributes("div", &["class"])
+            .add_tag_attributes("blockquote", &["class", "type"])
             .clean(&message().render_content_as_html())
-            .to_string()
+            .to_string();
+        split_quoted_content(&sanitized)
     });
+    let mut show_quoted = use_signal(|| false);
 
     rsx! {
         CardWithHeaders {
@@ -155,8 +159,94 @@ fn GoogleMailThreadMessage(message: ReadSignal<GoogleMailMessage>) -> Element {
 
             span {
                 class: "prose prose-sm prose-table:text-sm prose-img:max-w-none",
-                dangerous_inner_html: "{message_body()}"
+                dangerous_inner_html: "{message_parts().0}"
+            }
+            if let Some(quoted) = message_parts().1 {
+                button {
+                    class: "btn btn-xs btn-ghost px-2 py-0 min-h-0 h-5 align-middle text-neutral-content/60 hover:text-neutral-content",
+                    title: if show_quoted() { "Hide quoted content" } else { "Show quoted content" },
+                    onclick: move |_| { *show_quoted.write() = !show_quoted(); },
+                    "…"
+                }
+                if show_quoted() {
+                    span {
+                        class: "prose prose-sm prose-table:text-sm prose-img:max-w-none",
+                        dangerous_inner_html: "{quoted}"
+                    }
+                }
             }
         }
+    }
+}
+
+fn split_quoted_content(html: &str) -> (String, Option<String>) {
+    const MARKERS: &[&str] = &[
+        "<div class=\"gmail_quote",
+        "<blockquote type=\"cite\"",
+        "<blockquote class=\"gmail_quote",
+    ];
+    let earliest = MARKERS.iter().filter_map(|m| html.find(m)).min();
+    match earliest {
+        Some(pos) => (html[..pos].to_string(), Some(html[pos..].to_string())),
+        None => (html.to_string(), None),
+    }
+}
+
+#[cfg(test)]
+mod google_mail_preview_tests {
+    use super::split_quoted_content;
+    use pretty_assertions::assert_eq;
+    use wasm_bindgen_test::*;
+
+    #[wasm_bindgen_test]
+    fn no_quote_markers_returns_whole_html_and_none() {
+        let html = "<p>hello world</p>";
+        let (visible, quoted) = split_quoted_content(html);
+        assert_eq!(visible, html);
+        assert_eq!(quoted, None);
+    }
+
+    #[wasm_bindgen_test]
+    fn splits_at_gmail_quote_div() {
+        let html = r#"<p>new reply</p><div class="gmail_quote gmail_quote_container"><blockquote>old</blockquote></div>"#;
+        let (visible, quoted) = split_quoted_content(html);
+        assert_eq!(visible, "<p>new reply</p>");
+        assert_eq!(
+            quoted.as_deref(),
+            Some(
+                r#"<div class="gmail_quote gmail_quote_container"><blockquote>old</blockquote></div>"#
+            )
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn splits_at_blockquote_type_cite() {
+        let html = r#"<p>new reply</p><blockquote type="cite">old</blockquote>"#;
+        let (visible, quoted) = split_quoted_content(html);
+        assert_eq!(visible, "<p>new reply</p>");
+        assert_eq!(
+            quoted.as_deref(),
+            Some(r#"<blockquote type="cite">old</blockquote>"#)
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn splits_at_blockquote_class_gmail_quote() {
+        let html = r#"reply<br><blockquote class="gmail_quote">quoted</blockquote>"#;
+        let (visible, quoted) = split_quoted_content(html);
+        assert_eq!(visible, "reply<br>");
+        assert_eq!(
+            quoted.as_deref(),
+            Some(r#"<blockquote class="gmail_quote">quoted</blockquote>"#)
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn earliest_marker_wins_when_multiple_present() {
+        let html =
+            r#"<p>reply</p><blockquote type="cite">A</blockquote><div class="gmail_quote">B</div>"#;
+        let (visible, quoted) = split_quoted_content(html);
+        assert_eq!(visible, "<p>reply</p>");
+        assert!(quoted.unwrap().starts_with(r#"<blockquote type="cite""#));
     }
 }

--- a/web/src/components/integrations/google_mail/preview.rs
+++ b/web/src/components/integrations/google_mail/preview.rs
@@ -151,6 +151,7 @@ fn GoogleMailThreadMessage(message: ReadSignal<GoogleMailMessage>) -> Element {
         split_quoted_content(&sanitized)
     });
     let mut show_quoted = use_signal(|| false);
+    let (visible, quoted) = message_parts();
 
     rsx! {
         CardWithHeaders {
@@ -159,9 +160,9 @@ fn GoogleMailThreadMessage(message: ReadSignal<GoogleMailMessage>) -> Element {
 
             span {
                 class: "prose prose-sm prose-table:text-sm prose-img:max-w-none",
-                dangerous_inner_html: "{message_parts().0}"
+                dangerous_inner_html: "{visible}"
             }
-            if let Some(quoted) = message_parts().1 {
+            if let Some(quoted) = quoted {
                 button {
                     class: "btn btn-xs btn-ghost px-2 py-0 min-h-0 h-5 align-middle text-neutral-content/60 hover:text-neutral-content",
                     title: if show_quoted() { "Hide quoted content" } else { "Show quoted content" },

--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -13,10 +13,43 @@ cfg_if! {
     }
 }
 
+#[cfg(feature = "console_log")]
+mod filtered_logger {
+    use log::{Level, LevelFilter, Log, Metadata, Record};
+
+    const MODULE_CEILINGS: &[(&str, LevelFilter)] = &[("html5ever", LevelFilter::Warn)];
+
+    pub struct FilteredLogger {
+        pub default_level: Level,
+    }
+
+    impl Log for FilteredLogger {
+        fn enabled(&self, metadata: &Metadata) -> bool {
+            let ceiling = MODULE_CEILINGS
+                .iter()
+                .find(|(prefix, _)| metadata.target().starts_with(prefix))
+                .map(|(_, level)| *level)
+                .unwrap_or_else(|| self.default_level.to_level_filter());
+            metadata.level().to_level_filter() <= ceiling
+        }
+
+        fn log(&self, record: &Record) {
+            if self.enabled(record.metadata()) {
+                console_log::log(record);
+            }
+        }
+
+        fn flush(&self) {}
+    }
+}
+
 cfg_if! {
     if #[cfg(feature = "console_log")] {
+        static LOGGER: filtered_logger::FilteredLogger = filtered_logger::FilteredLogger { default_level: LOG_LEVEL };
+
         fn init_log() {
-            console_log::init_with_level(LOG_LEVEL).expect("error initializing log");
+            log::set_logger(&LOGGER).expect("error initializing log");
+            log::set_max_level(LOG_LEVEL.to_level_filter());
             info!("Log level set to {}", LOG_LEVEL);
         }
     } else {


### PR DESCRIPTION
## Summary

- Collapse quoted prior replies in Gmail thread previews by default, with an inline `…` toggle to reveal them (mirroring Gmail/Apple Mail behavior).
- Fix a Dioxus closure re-entrancy crash that the feature initially introduced on some real emails.
- Silence `html5ever` debug/trace logs that were flooding the devtools console and slowing large-email preview rendering.

## Commits

- `60986e08` feat: Hide quoted content in Gmail email previews
  - Backend (shared domain crate): `render_text_body_as_html` now wraps contiguous `>`-prefixed plain-text lines in `<blockquote class="gmail_quote">`, so the frontend detector works against one unified HTML marker set.
  - Frontend: extend ammonia to preserve `class`/`type` on `div`/`blockquote`, split sanitized HTML at the earliest `gmail_quote` / `blockquote type="cite"` marker, render the visible half normally, and show an inline `…` button that toggles the quoted half.
  - Dev fixture (`google_mail_thread_get_123.json`): real Gmail HTML body with a `gmail_quote` block so `just api generate-user` now produces a realistic sample exercising the feature.
- `c47dba43` fix: Read Gmail message parts memo once per render
  - The memo was being read twice inside `rsx!`, which combined with the sibling `show_quoted` signal could trigger Dioxus's "closure invoked recursively or after being dropped" wasm-bindgen assertion on some real emails. Destructure once at the top of the component.
- `5db34fae` perf(web): Silence html5ever debug/trace logs
  - Install a tiny filtering `log::Log` wrapper that caps `html5ever::*` below `Warn` and forwards other records to `console_log::log`. Because `Log::enabled` gates before argument formatting, this also eliminates the string-formatting cost at the call sites.

## Test plan

- [x] `just check` at workspace root — clean
- [x] Backend unit tests: `just test google_mail` — 16/16 passing (7 new for plain-text quote wrapping)
- [x] Frontend unit tests: `cd web && just test split_quoted_content` — 5/5 passing
- [x] API integration tests with updated fixture: `just api test google_mail` — 21/21 passing
- [x] Browser regression — Google security alert (no quotes): 1 span, no toggle button, no errors
- [x] Browser golden path — test-user fixture email with quoted content: `…` button visible; click expands quoted half, title flips to "Hide quoted content"; click again collapses; title flips back to "Show quoted content"
- [x] Browser crash fix — `/notifications/baadc44d-…` (Cloudflare certificate renewal) now renders without the "closure invoked recursively" console error
- [x] Log filtering — devtools console shows zero `html5ever` records after loading large emails; app-level `web/src/...` debug logs still visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/universal-inbox/universal-inbox/pull/160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added collapsible quoted content in Google Mail message previews with expand/collapse toggle.

* **Bug Fixes**
  * Improved rendering of quoted text in plain text emails with proper blockquote formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->