### PR TITLE
feat: Internalize OAuth for GitHub, Slack, Todoist, and Google integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add MCP (Model Context Protocol) server for AI agent integration
 - Add configurable emoji on Slack task completion
 - Hide quoted content in Gmail email previews
+- Internalize OAuth for GitHub, Slack, Todoist, Google Mail, Google Calendar, and Google Drive (replace Nango).
 
 ### Changed
 

--- a/api/config/default.toml
+++ b/api/config/default.toml
@@ -116,6 +116,9 @@ kind = "Github"
 nango_key = "github"
 page_size = 50
 required_oauth_scopes = ["notifications", "read:discussion", "read:org", "repo"]
+# OAuth client credentials from https://github.com/settings/developers
+# oauth_client_id = ""
+# oauth_client_secret = ""
 # Rate limiting configuration
 api_max_retry_duration_http_seconds = 30
 api_max_retry_duration_worker_seconds = 600
@@ -138,6 +141,9 @@ kind = "GoogleMail"
 nango_key = "google-mail"
 page_size = 500
 required_oauth_scopes = ["https://www.googleapis.com/auth/gmail.modify"]
+# OAuth client credentials from https://console.cloud.google.com/apis/credentials
+# oauth_client_id = ""
+# oauth_client_secret = ""
 warning_message = "Google Mail integration is not yet public, it requires your email address to be whitelisted and you will see a warning message from Google while connecting. If you still want to connect it, please send the Google email address you want to use to the [support](mailto:support@universal-inbox.com)."
 # Rate limiting configuration
 api_max_retry_duration_http_seconds = 30
@@ -148,6 +154,9 @@ name = "Google Calendar"
 kind = "GoogleCalendar"
 nango_key = "google-calendar"
 required_oauth_scopes = ["https://www.googleapis.com/auth/calendar"]
+# OAuth client credentials from https://console.cloud.google.com/apis/credentials
+# oauth_client_id = ""
+# oauth_client_secret = ""
 # Rate limiting configuration
 api_max_retry_duration_http_seconds = 30
 api_max_retry_duration_worker_seconds = 600
@@ -158,6 +167,9 @@ kind = "GoogleDrive"
 nango_key = "google-drive"
 page_size = 100
 required_oauth_scopes = ["https://www.googleapis.com/auth/drive.readonly", "https://www.googleapis.com/auth/drive.metadata.readonly"]
+# OAuth client credentials from https://console.cloud.google.com/apis/credentials
+# oauth_client_id = ""
+# oauth_client_secret = ""
 warning_message = "Google Drive integration is not yet public, it requires your email address to be whitelisted and you will see a warning message from Google while connecting. If you still want to connect it, please send the Google email address you want to use to the [support](mailto:support@universal-inbox.com)."
 # Rate limiting configuration
 api_max_retry_duration_http_seconds = 30
@@ -168,6 +180,9 @@ name = "Todoist"
 kind = "Todoist"
 nango_key = "todoist"
 required_oauth_scopes = ["data:read_write", "data:delete"]
+# OAuth client credentials from https://app.todoist.com/app/settings/integrations/app-management
+# oauth_client_id = ""
+# oauth_client_secret = ""
 # Rate limiting configuration
 api_max_retry_duration_http_seconds = 30
 api_max_retry_duration_worker_seconds = 600
@@ -193,6 +208,9 @@ required_oauth_scopes = [
   "users:read",
 ]
 use_as_oauth_user_scopes = true
+# OAuth client credentials from https://api.slack.com/apps
+# oauth_client_id = ""
+# oauth_client_secret = ""
 
 [integrations.ticktick]
 name = "Tick Tick"

--- a/api/src/integrations/github/mod.rs
+++ b/api/src/integrations/github/mod.rs
@@ -47,6 +47,7 @@ use crate::{
 
 pub mod graphql;
 pub mod notification;
+pub mod oauth;
 
 #[derive(Clone)]
 pub struct GithubService {

--- a/api/src/integrations/github/oauth.rs
+++ b/api/src/integrations/github/oauth.rs
@@ -1,0 +1,176 @@
+use http::{HeaderMap, HeaderValue, header::ACCEPT};
+use secrecy::SecretBox;
+use serde_json::Value;
+use universal_inbox::integration_connection::provider::{
+    IntegrationConnectionContext, IntegrationProviderKind,
+};
+use url::Url;
+
+use crate::{
+    integrations::oauth2::{ClientSecret, provider::OAuth2Provider},
+    universal_inbox::UniversalInboxError,
+};
+
+pub struct GithubOAuth2Provider {
+    authorize_url: Url,
+    token_url: Url,
+    client_id: String,
+    client_secret: SecretBox<ClientSecret>,
+    required_scopes: Vec<String>,
+}
+
+impl std::fmt::Debug for GithubOAuth2Provider {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("GithubOAuth2Provider")
+            .field("authorize_url", &self.authorize_url)
+            .field("token_url", &self.token_url)
+            .field("client_id", &self.client_id)
+            .field("required_scopes", &self.required_scopes)
+            .finish_non_exhaustive()
+    }
+}
+
+impl GithubOAuth2Provider {
+    pub fn new(
+        client_id: String,
+        client_secret: SecretBox<ClientSecret>,
+        required_scopes: Vec<String>,
+    ) -> Self {
+        Self {
+            authorize_url: Url::parse("https://github.com/login/oauth/authorize")
+                .expect("Invalid Github authorize URL"),
+            token_url: Url::parse("https://github.com/login/oauth/access_token")
+                .expect("Invalid Github token URL"),
+            client_id,
+            client_secret,
+            required_scopes,
+        }
+    }
+}
+
+impl OAuth2Provider for GithubOAuth2Provider {
+    fn provider_kind(&self) -> IntegrationProviderKind {
+        IntegrationProviderKind::Github
+    }
+
+    fn authorize_url(&self) -> &Url {
+        &self.authorize_url
+    }
+
+    fn token_url(&self) -> &Url {
+        &self.token_url
+    }
+
+    fn client_id(&self) -> &str {
+        &self.client_id
+    }
+
+    fn client_secret(&self) -> &SecretBox<ClientSecret> {
+        &self.client_secret
+    }
+
+    fn required_scopes(&self) -> &[String] {
+        &self.required_scopes
+    }
+
+    fn supports_pkce(&self) -> bool {
+        false
+    }
+
+    fn migration_url(&self) -> Option<&Url> {
+        None
+    }
+
+    fn extract_registered_scopes(
+        &self,
+        raw_response: &Value,
+    ) -> Result<Vec<String>, UniversalInboxError> {
+        Ok(raw_response
+            .get("scope")
+            .and_then(|s| s.as_str())
+            .unwrap_or_default()
+            .split(',')
+            .filter(|s| !s.is_empty())
+            .map(|s| s.trim().to_string())
+            .collect())
+    }
+
+    fn extract_provider_user_id(&self, _raw_response: &Value) -> Option<String> {
+        None
+    }
+
+    fn extract_provider_context(
+        &self,
+        _raw_response: &Value,
+    ) -> Option<IntegrationConnectionContext> {
+        None
+    }
+
+    fn token_request_headers(&self) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
+        headers
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use serde_json::json;
+
+    fn provider() -> GithubOAuth2Provider {
+        GithubOAuth2Provider::new(
+            "test-client-id".to_string(),
+            SecretBox::new(Box::new(ClientSecret("test-client-secret".to_string()))),
+            vec!["repo".to_string(), "read:org".to_string()],
+        )
+    }
+
+    #[test]
+    fn test_provider_kind() {
+        assert_eq!(provider().provider_kind(), IntegrationProviderKind::Github);
+    }
+
+    #[test]
+    fn test_supports_pkce() {
+        assert!(!provider().supports_pkce());
+    }
+
+    #[test]
+    fn test_migration_url_is_none() {
+        assert!(provider().migration_url().is_none());
+    }
+
+    #[test]
+    fn test_scope_delimiter_is_comma() {
+        assert_eq!(provider().scope_delimiter(), ",");
+    }
+
+    #[test]
+    fn test_extract_scopes_comma_separated() {
+        let raw = json!({ "scope": "repo,read:org,notifications" });
+        let scopes = provider().extract_registered_scopes(&raw).unwrap();
+        assert_eq!(scopes, vec!["repo", "read:org", "notifications"]);
+    }
+
+    #[test]
+    fn test_extract_scopes_missing() {
+        let raw = json!({});
+        assert!(
+            provider()
+                .extract_registered_scopes(&raw)
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn test_token_request_headers_include_accept_json() {
+        let headers = provider().token_request_headers();
+        assert_eq!(
+            headers.get(ACCEPT).and_then(|v| v.to_str().ok()),
+            Some("application/json")
+        );
+    }
+}

--- a/api/src/integrations/google_oauth.rs
+++ b/api/src/integrations/google_oauth.rs
@@ -1,0 +1,207 @@
+use secrecy::SecretBox;
+use serde_json::Value;
+use universal_inbox::integration_connection::provider::{
+    IntegrationConnectionContext, IntegrationProviderKind,
+};
+use url::Url;
+
+use crate::{
+    integrations::oauth2::{ClientSecret, provider::OAuth2Provider},
+    universal_inbox::UniversalInboxError,
+};
+
+/// Shared OAuth2 provider for Google Mail, Calendar, and Drive.
+/// Google uses the same OAuth2 endpoints across all its APIs; only the
+/// `provider_kind` differs. The requested scopes (set via config) determine
+/// which API the issued token can access.
+pub struct GoogleOAuth2Provider {
+    provider_kind: IntegrationProviderKind,
+    authorize_url: Url,
+    token_url: Url,
+    client_id: String,
+    client_secret: SecretBox<ClientSecret>,
+    required_scopes: Vec<String>,
+}
+
+impl std::fmt::Debug for GoogleOAuth2Provider {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("GoogleOAuth2Provider")
+            .field("provider_kind", &self.provider_kind)
+            .field("authorize_url", &self.authorize_url)
+            .field("token_url", &self.token_url)
+            .field("client_id", &self.client_id)
+            .field("required_scopes", &self.required_scopes)
+            .finish_non_exhaustive()
+    }
+}
+
+impl GoogleOAuth2Provider {
+    pub fn new(
+        provider_kind: IntegrationProviderKind,
+        client_id: String,
+        client_secret: SecretBox<ClientSecret>,
+        required_scopes: Vec<String>,
+    ) -> Self {
+        Self {
+            provider_kind,
+            authorize_url: Url::parse("https://accounts.google.com/o/oauth2/v2/auth")
+                .expect("Invalid Google authorize URL"),
+            token_url: Url::parse("https://oauth2.googleapis.com/token")
+                .expect("Invalid Google token URL"),
+            client_id,
+            client_secret,
+            required_scopes,
+        }
+    }
+}
+
+impl OAuth2Provider for GoogleOAuth2Provider {
+    fn provider_kind(&self) -> IntegrationProviderKind {
+        self.provider_kind
+    }
+
+    fn authorize_url(&self) -> &Url {
+        &self.authorize_url
+    }
+
+    fn token_url(&self) -> &Url {
+        &self.token_url
+    }
+
+    fn client_id(&self) -> &str {
+        &self.client_id
+    }
+
+    fn client_secret(&self) -> &SecretBox<ClientSecret> {
+        &self.client_secret
+    }
+
+    fn required_scopes(&self) -> &[String] {
+        &self.required_scopes
+    }
+
+    fn supports_pkce(&self) -> bool {
+        true
+    }
+
+    fn migration_url(&self) -> Option<&Url> {
+        None
+    }
+
+    fn scope_delimiter(&self) -> &'static str {
+        " "
+    }
+
+    fn extra_authorize_params(&self) -> Vec<(&'static str, &'static str)> {
+        // access_type=offline + prompt=consent ensures Google returns a refresh_token
+        // on every authorization (not just the first), and allows long-lived refresh.
+        vec![("access_type", "offline"), ("prompt", "consent")]
+    }
+
+    fn extract_registered_scopes(
+        &self,
+        raw_response: &Value,
+    ) -> Result<Vec<String>, UniversalInboxError> {
+        Ok(raw_response
+            .get("scope")
+            .and_then(|s| s.as_str())
+            .unwrap_or_default()
+            .split(' ')
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .collect())
+    }
+
+    fn extract_provider_user_id(&self, _raw_response: &Value) -> Option<String> {
+        None
+    }
+
+    fn extract_provider_context(
+        &self,
+        _raw_response: &Value,
+    ) -> Option<IntegrationConnectionContext> {
+        // Google Mail / Drive contexts (user email, labels, etc.) are populated
+        // by the per-integration sync services after the first successful API call,
+        // not from the OAuth token response.
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use serde_json::json;
+
+    fn mail_provider() -> GoogleOAuth2Provider {
+        GoogleOAuth2Provider::new(
+            IntegrationProviderKind::GoogleMail,
+            "test-client-id".to_string(),
+            SecretBox::new(Box::new(ClientSecret("test-client-secret".to_string()))),
+            vec!["https://www.googleapis.com/auth/gmail.modify".to_string()],
+        )
+    }
+
+    #[test]
+    fn test_provider_kind_varies() {
+        assert_eq!(
+            mail_provider().provider_kind(),
+            IntegrationProviderKind::GoogleMail
+        );
+        let cal = GoogleOAuth2Provider::new(
+            IntegrationProviderKind::GoogleCalendar,
+            "cid".to_string(),
+            SecretBox::new(Box::new(ClientSecret("cs".to_string()))),
+            vec![],
+        );
+        assert_eq!(cal.provider_kind(), IntegrationProviderKind::GoogleCalendar);
+    }
+
+    #[test]
+    fn test_supports_pkce() {
+        assert!(mail_provider().supports_pkce());
+    }
+
+    #[test]
+    fn test_migration_url_is_none() {
+        assert!(mail_provider().migration_url().is_none());
+    }
+
+    #[test]
+    fn test_scope_delimiter_is_space() {
+        assert_eq!(mail_provider().scope_delimiter(), " ");
+    }
+
+    #[test]
+    fn test_extra_authorize_params_include_offline_and_consent() {
+        let params = mail_provider().extra_authorize_params();
+        assert!(params.contains(&("access_type", "offline")));
+        assert!(params.contains(&("prompt", "consent")));
+    }
+
+    #[test]
+    fn test_extract_scopes_space_separated() {
+        let raw = json!({
+            "scope": "https://www.googleapis.com/auth/gmail.modify https://www.googleapis.com/auth/userinfo.email"
+        });
+        let scopes = mail_provider().extract_registered_scopes(&raw).unwrap();
+        assert_eq!(
+            scopes,
+            vec![
+                "https://www.googleapis.com/auth/gmail.modify".to_string(),
+                "https://www.googleapis.com/auth/userinfo.email".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_extract_scopes_missing() {
+        let raw = json!({});
+        assert!(
+            mail_provider()
+                .extract_registered_scopes(&raw)
+                .unwrap()
+                .is_empty()
+        );
+    }
+}

--- a/api/src/integrations/mod.rs
+++ b/api/src/integrations/mod.rs
@@ -22,10 +22,13 @@ pub mod github;
 pub mod google_calendar;
 pub mod google_drive;
 pub mod google_mail;
+pub mod google_oauth;
 pub mod linear;
 pub mod oauth2;
 pub mod slack;
+pub mod slack_oauth;
 pub mod todoist;
+pub mod todoist_oauth;
 
 pub mod third_party {
     use super::*;

--- a/api/src/integrations/oauth2/provider.rs
+++ b/api/src/integrations/oauth2/provider.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 use anyhow::Context;
 use chrono::{DateTime, TimeDelta, Utc};
+use http::HeaderMap;
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware, Extension};
 use reqwest_tracing::{DisableOtelPropagation, SpanBackendWithUrl, TracingMiddleware};
 use secrecy::{ExposeSecret, SecretBox};
@@ -86,6 +87,56 @@ pub trait OAuth2Provider: Send + Sync + std::fmt::Debug {
         &self,
         raw_response: &Value,
     ) -> Option<IntegrationConnectionContext>;
+
+    /// Extra query params to append to the authorize URL (e.g. Google's
+    /// `access_type=offline` / `prompt=consent`). Default: none.
+    fn extra_authorize_params(&self) -> Vec<(&'static str, &'static str)> {
+        Vec::new()
+    }
+
+    /// Delimiter used when joining scopes in the authorize URL scope param.
+    /// Defaults to "," (Linear / GitHub). Providers using RFC 6749 space
+    /// separation override to " ".
+    fn scope_delimiter(&self) -> &'static str {
+        ","
+    }
+
+    /// Name of the scope query parameter. Defaults to "scope". Slack with
+    /// `use_as_oauth_user_scopes = true` overrides to "user_scope".
+    fn scope_param_name(&self) -> &'static str {
+        "scope"
+    }
+
+    /// Extra HTTP headers to send with token exchange / refresh requests
+    /// (e.g. GitHub requires `Accept: application/json`). Default: none.
+    fn token_request_headers(&self) -> HeaderMap {
+        HeaderMap::new()
+    }
+
+    /// Parse the raw token endpoint response body into an `OAuthTokenResponse`.
+    /// Default implementation parses standard OAuth2 JSON; providers with
+    /// non-standard response shapes (e.g. Slack v2) can override.
+    fn parse_token_response(&self, body: &str) -> Result<OAuthTokenResponse, UniversalInboxError> {
+        serde_json::from_str(body)
+            .map_err(|err| UniversalInboxError::from_json_serde_error(err, body.to_string()))
+    }
+
+    /// Return a copy of the raw provider response with secret material stripped
+    /// (access tokens, refresh tokens, id tokens). The result is what gets
+    /// persisted to `oauth_credential.raw_response`.
+    ///
+    /// Default: strip well-known top-level OAuth2 token fields. Providers with
+    /// non-standard shapes (e.g. Slack) MUST override to also strip nested
+    /// occurrences.
+    fn sanitize_raw_response(&self, raw: &Value) -> Value {
+        let mut cleaned = raw.clone();
+        if let Some(obj) = cleaned.as_object_mut() {
+            for key in ["access_token", "refresh_token", "id_token"] {
+                obj.remove(key);
+            }
+        }
+        cleaned
+    }
 }
 
 /// Service that executes OAuth2 flows (authorization URL generation, code exchange,
@@ -147,6 +198,7 @@ impl OAuth2FlowService {
         let response = self
             .client
             .post(provider.token_url().as_str())
+            .headers(provider.token_request_headers())
             .form(&params)
             .send()
             .await
@@ -164,8 +216,7 @@ impl OAuth2FlowService {
             )));
         }
 
-        serde_json::from_str(&body)
-            .map_err(|err| UniversalInboxError::from_json_serde_error(err, body))
+        provider.parse_token_response(&body)
     }
 
     pub async fn refresh_access_token(
@@ -190,6 +241,7 @@ impl OAuth2FlowService {
         let response = self
             .client
             .post(provider.token_url().as_str())
+            .headers(provider.token_request_headers())
             .form(&params)
             .send()
             .await
@@ -207,8 +259,7 @@ impl OAuth2FlowService {
             )));
         }
 
-        serde_json::from_str(&body)
-            .map_err(|err| UniversalInboxError::from_json_serde_error(err, body))
+        provider.parse_token_response(&body)
     }
 
     /// Migrate an existing long-lived token to short-lived + refresh token.
@@ -240,6 +291,7 @@ impl OAuth2FlowService {
         let response = self
             .client
             .post(migration_url.as_str())
+            .headers(provider.token_request_headers())
             .form(&params)
             .send()
             .await
@@ -257,8 +309,7 @@ impl OAuth2FlowService {
             )));
         }
 
-        serde_json::from_str(&body)
-            .map_err(|err| UniversalInboxError::from_json_serde_error(err, body))
+        provider.parse_token_response(&body)
     }
 }
 

--- a/api/src/integrations/slack_oauth.rs
+++ b/api/src/integrations/slack_oauth.rs
@@ -1,0 +1,316 @@
+use secrecy::SecretBox;
+use serde_json::Value;
+use slack_morphism::SlackTeamId;
+use universal_inbox::integration_connection::{
+    integrations::slack::SlackContext,
+    provider::{IntegrationConnectionContext, IntegrationProviderKind},
+};
+use url::Url;
+
+use crate::{
+    integrations::oauth2::{
+        AccessToken, ClientSecret, RefreshToken,
+        provider::{OAuth2Provider, OAuthTokenResponse},
+    },
+    universal_inbox::UniversalInboxError,
+};
+
+pub struct SlackOAuth2Provider {
+    authorize_url: Url,
+    token_url: Url,
+    client_id: String,
+    client_secret: SecretBox<ClientSecret>,
+    required_scopes: Vec<String>,
+}
+
+impl std::fmt::Debug for SlackOAuth2Provider {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("SlackOAuth2Provider")
+            .field("authorize_url", &self.authorize_url)
+            .field("token_url", &self.token_url)
+            .field("client_id", &self.client_id)
+            .field("required_scopes", &self.required_scopes)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SlackOAuth2Provider {
+    pub fn new(
+        client_id: String,
+        client_secret: SecretBox<ClientSecret>,
+        required_scopes: Vec<String>,
+    ) -> Self {
+        Self {
+            authorize_url: Url::parse("https://slack.com/oauth/v2/authorize")
+                .expect("Invalid Slack authorize URL"),
+            token_url: Url::parse("https://slack.com/api/oauth.v2.access")
+                .expect("Invalid Slack token URL"),
+            client_id,
+            client_secret,
+            required_scopes,
+        }
+    }
+}
+
+impl OAuth2Provider for SlackOAuth2Provider {
+    fn provider_kind(&self) -> IntegrationProviderKind {
+        IntegrationProviderKind::Slack
+    }
+
+    fn authorize_url(&self) -> &Url {
+        &self.authorize_url
+    }
+
+    fn token_url(&self) -> &Url {
+        &self.token_url
+    }
+
+    fn client_id(&self) -> &str {
+        &self.client_id
+    }
+
+    fn client_secret(&self) -> &SecretBox<ClientSecret> {
+        &self.client_secret
+    }
+
+    fn required_scopes(&self) -> &[String] {
+        &self.required_scopes
+    }
+
+    fn supports_pkce(&self) -> bool {
+        false
+    }
+
+    fn migration_url(&self) -> Option<&Url> {
+        None
+    }
+
+    fn scope_param_name(&self) -> &'static str {
+        // Slack requested scopes are user scopes (use_as_oauth_user_scopes = true)
+        "user_scope"
+    }
+
+    fn extract_registered_scopes(
+        &self,
+        raw_response: &Value,
+    ) -> Result<Vec<String>, UniversalInboxError> {
+        Ok(raw_response["authed_user"]["scope"]
+            .as_str()
+            .unwrap_or_default()
+            .split(',')
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .collect())
+    }
+
+    fn extract_provider_user_id(&self, raw_response: &Value) -> Option<String> {
+        raw_response["authed_user"]["id"]
+            .as_str()
+            .map(|s| s.to_string())
+    }
+
+    fn extract_provider_context(
+        &self,
+        raw_response: &Value,
+    ) -> Option<IntegrationConnectionContext> {
+        let team_id = raw_response["team"]["id"].as_str()?.to_string();
+        Some(IntegrationConnectionContext::Slack(SlackContext {
+            team_id: SlackTeamId(team_id),
+            extension_credentials: vec![],
+            last_extension_heartbeat_at: None,
+        }))
+    }
+
+    fn sanitize_raw_response(&self, raw: &Value) -> Value {
+        let mut cleaned = raw.clone();
+        if let Some(obj) = cleaned.as_object_mut() {
+            for key in ["access_token", "refresh_token", "id_token"] {
+                obj.remove(key);
+            }
+            if let Some(authed) = obj.get_mut("authed_user").and_then(|v| v.as_object_mut()) {
+                for key in ["access_token", "refresh_token", "id_token"] {
+                    authed.remove(key);
+                }
+            }
+        }
+        cleaned
+    }
+
+    fn parse_token_response(&self, body: &str) -> Result<OAuthTokenResponse, UniversalInboxError> {
+        // Slack OAuth v2 returns `{ "ok": true, "authed_user": { "access_token": "...", ... }, ... }`
+        // when user scopes are requested. The bot token (top-level access_token) may or may not
+        // be present. We persist the user token.
+        let raw: Value = serde_json::from_str(body)
+            .map_err(|err| UniversalInboxError::from_json_serde_error(err, body.to_string()))?;
+
+        if raw.get("ok").and_then(|v| v.as_bool()) != Some(true) {
+            let err_msg = raw
+                .get("error")
+                .and_then(|e| e.as_str())
+                .unwrap_or("unknown error");
+            return Err(UniversalInboxError::Unexpected(anyhow::anyhow!(
+                "Slack token exchange failed: {err_msg} (body: {body})"
+            )));
+        }
+
+        let access_token = raw["authed_user"]["access_token"]
+            .as_str()
+            .or_else(|| raw["access_token"].as_str())
+            .ok_or_else(|| {
+                UniversalInboxError::Unexpected(anyhow::anyhow!(
+                    "Slack token response missing access_token (body: {body})"
+                ))
+            })?
+            .to_string();
+
+        let refresh_token = raw["authed_user"]["refresh_token"]
+            .as_str()
+            .or_else(|| raw["refresh_token"].as_str())
+            .map(|t| SecretBox::new(Box::new(RefreshToken(t.to_string()))));
+
+        let expires_in = raw["authed_user"]["expires_in"]
+            .as_i64()
+            .or_else(|| raw["expires_in"].as_i64());
+
+        Ok(OAuthTokenResponse {
+            access_token: SecretBox::new(Box::new(AccessToken(access_token))),
+            refresh_token,
+            token_type: raw
+                .get("token_type")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string()),
+            expires_in,
+            extra: raw,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use secrecy::ExposeSecret;
+    use serde_json::json;
+
+    fn provider() -> SlackOAuth2Provider {
+        SlackOAuth2Provider::new(
+            "test-client-id".to_string(),
+            SecretBox::new(Box::new(ClientSecret("test-client-secret".to_string()))),
+            vec!["channels:read".to_string(), "chat:write".to_string()],
+        )
+    }
+
+    #[test]
+    fn test_provider_kind() {
+        assert_eq!(provider().provider_kind(), IntegrationProviderKind::Slack);
+    }
+
+    #[test]
+    fn test_supports_pkce() {
+        assert!(!provider().supports_pkce());
+    }
+
+    #[test]
+    fn test_migration_url_is_none() {
+        assert!(provider().migration_url().is_none());
+    }
+
+    #[test]
+    fn test_scope_param_name() {
+        assert_eq!(provider().scope_param_name(), "user_scope");
+    }
+
+    #[test]
+    fn test_extract_scopes() {
+        let raw = json!({
+            "authed_user": { "scope": "channels:read,chat:write,users:read" }
+        });
+        let scopes = provider().extract_registered_scopes(&raw).unwrap();
+        assert_eq!(scopes, vec!["channels:read", "chat:write", "users:read"]);
+    }
+
+    #[test]
+    fn test_extract_provider_user_id() {
+        let raw = json!({ "authed_user": { "id": "U123456" } });
+        assert_eq!(
+            provider().extract_provider_user_id(&raw),
+            Some("U123456".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_provider_context_returns_team_id() {
+        let raw = json!({ "team": { "id": "T98765" } });
+        match provider().extract_provider_context(&raw) {
+            Some(IntegrationConnectionContext::Slack(ctx)) => {
+                assert_eq!(ctx.team_id.0, "T98765");
+            }
+            other => panic!("expected Slack context, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_extract_provider_context_none_without_team() {
+        let raw = json!({ "authed_user": { "id": "U1" } });
+        assert!(provider().extract_provider_context(&raw).is_none());
+    }
+
+    #[test]
+    fn test_parse_token_response_reads_authed_user_access_token() {
+        let body = r#"{
+            "ok": true,
+            "app_id": "A1",
+            "authed_user": {
+                "id": "U1",
+                "scope": "channels:read,chat:write",
+                "access_token": "xoxp-user-token",
+                "token_type": "user"
+            },
+            "team": { "id": "T1", "name": "team" }
+        }"#;
+        let response = provider().parse_token_response(body).unwrap();
+        assert_eq!(
+            response.access_token.expose_secret().as_str(),
+            "xoxp-user-token"
+        );
+        assert!(response.refresh_token.is_none());
+    }
+
+    #[test]
+    fn test_sanitize_raw_response_strips_tokens_keeps_identity() {
+        let raw = json!({
+            "ok": true,
+            "access_token": "xoxb-bot-token",
+            "refresh_token": "xoxe-bot-refresh",
+            "authed_user": {
+                "id": "U1",
+                "scope": "channels:read",
+                "access_token": "xoxp-user-token",
+                "refresh_token": "xoxe-user-refresh",
+            },
+            "team": { "id": "T1", "name": "team" }
+        });
+        let cleaned = provider().sanitize_raw_response(&raw);
+        assert!(cleaned.get("access_token").is_none());
+        assert!(cleaned.get("refresh_token").is_none());
+        let authed = cleaned.get("authed_user").unwrap();
+        assert_eq!(authed.get("id").and_then(|v| v.as_str()), Some("U1"));
+        assert_eq!(
+            authed.get("scope").and_then(|v| v.as_str()),
+            Some("channels:read")
+        );
+        assert!(authed.get("access_token").is_none());
+        assert!(authed.get("refresh_token").is_none());
+        assert_eq!(
+            cleaned["team"]["id"].as_str(),
+            Some("T1"),
+            "team.id must be preserved"
+        );
+    }
+
+    #[test]
+    fn test_parse_token_response_errors_when_not_ok() {
+        let body = r#"{ "ok": false, "error": "invalid_code" }"#;
+        assert!(provider().parse_token_response(body).is_err());
+    }
+}

--- a/api/src/integrations/todoist_oauth.rs
+++ b/api/src/integrations/todoist_oauth.rs
@@ -1,0 +1,147 @@
+use secrecy::SecretBox;
+use serde_json::Value;
+use universal_inbox::integration_connection::provider::{
+    IntegrationConnectionContext, IntegrationProviderKind,
+};
+use url::Url;
+
+use crate::{
+    integrations::oauth2::{ClientSecret, provider::OAuth2Provider},
+    universal_inbox::UniversalInboxError,
+};
+
+pub struct TodoistOAuth2Provider {
+    authorize_url: Url,
+    token_url: Url,
+    client_id: String,
+    client_secret: SecretBox<ClientSecret>,
+    required_scopes: Vec<String>,
+}
+
+impl std::fmt::Debug for TodoistOAuth2Provider {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("TodoistOAuth2Provider")
+            .field("authorize_url", &self.authorize_url)
+            .field("token_url", &self.token_url)
+            .field("client_id", &self.client_id)
+            .field("required_scopes", &self.required_scopes)
+            .finish_non_exhaustive()
+    }
+}
+
+impl TodoistOAuth2Provider {
+    pub fn new(
+        client_id: String,
+        client_secret: SecretBox<ClientSecret>,
+        required_scopes: Vec<String>,
+    ) -> Self {
+        Self {
+            authorize_url: Url::parse("https://todoist.com/oauth/authorize")
+                .expect("Invalid Todoist authorize URL"),
+            token_url: Url::parse("https://todoist.com/oauth/access_token")
+                .expect("Invalid Todoist token URL"),
+            client_id,
+            client_secret,
+            required_scopes,
+        }
+    }
+}
+
+impl OAuth2Provider for TodoistOAuth2Provider {
+    fn provider_kind(&self) -> IntegrationProviderKind {
+        IntegrationProviderKind::Todoist
+    }
+
+    fn authorize_url(&self) -> &Url {
+        &self.authorize_url
+    }
+
+    fn token_url(&self) -> &Url {
+        &self.token_url
+    }
+
+    fn client_id(&self) -> &str {
+        &self.client_id
+    }
+
+    fn client_secret(&self) -> &SecretBox<ClientSecret> {
+        &self.client_secret
+    }
+
+    fn required_scopes(&self) -> &[String] {
+        &self.required_scopes
+    }
+
+    fn supports_pkce(&self) -> bool {
+        false
+    }
+
+    fn migration_url(&self) -> Option<&Url> {
+        None
+    }
+
+    fn extract_registered_scopes(
+        &self,
+        _raw_response: &Value,
+    ) -> Result<Vec<String>, UniversalInboxError> {
+        // Todoist does not include scopes in the token response.
+        Ok(vec![])
+    }
+
+    fn extract_provider_user_id(&self, _raw_response: &Value) -> Option<String> {
+        None
+    }
+
+    fn extract_provider_context(
+        &self,
+        _raw_response: &Value,
+    ) -> Option<IntegrationConnectionContext> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use serde_json::json;
+
+    fn provider() -> TodoistOAuth2Provider {
+        TodoistOAuth2Provider::new(
+            "test-client-id".to_string(),
+            SecretBox::new(Box::new(ClientSecret("test-client-secret".to_string()))),
+            vec!["data:read_write".to_string(), "data:delete".to_string()],
+        )
+    }
+
+    #[test]
+    fn test_provider_kind() {
+        assert_eq!(provider().provider_kind(), IntegrationProviderKind::Todoist);
+    }
+
+    #[test]
+    fn test_supports_pkce() {
+        assert!(!provider().supports_pkce());
+    }
+
+    #[test]
+    fn test_migration_url_is_none() {
+        assert!(provider().migration_url().is_none());
+    }
+
+    #[test]
+    fn test_scope_delimiter_is_comma() {
+        assert_eq!(provider().scope_delimiter(), ",");
+    }
+
+    #[test]
+    fn test_extract_scopes_always_empty() {
+        let raw = json!({ "access_token": "abc", "token_type": "bearer" });
+        assert!(
+            provider()
+                .extract_registered_scopes(&raw)
+                .unwrap()
+                .is_empty()
+        );
+    }
+}

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -55,15 +55,18 @@ use webauthn_rs::prelude::*;
 use crate::{
     configuration::Settings,
     integrations::{
-        github::GithubService,
+        github::{GithubService, oauth::GithubOAuth2Provider},
         google_drive::GoogleDriveService,
         google_mail::GoogleMailService,
+        google_oauth::GoogleOAuth2Provider,
         linear::{LinearService, oauth::LinearOAuth2Provider},
         oauth2::{
             NangoService,
             provider::{OAuth2FlowService, OAuth2Provider},
         },
+        slack_oauth::SlackOAuth2Provider,
         todoist::TodoistService,
+        todoist_oauth::TodoistOAuth2Provider,
     },
     jobs::handle_universal_inbox_job,
     observability::AuthenticatedRootSpanBuilder,
@@ -505,6 +508,73 @@ pub async fn build_services(
                 linear_settings.required_oauth_scopes.clone(),
             )),
         );
+    }
+    if let Some(github_settings) = settings.integrations.get("github")
+        && let (Some(client_id), Some(client_secret)) = (
+            github_settings.oauth_client_id.as_ref(),
+            github_settings.oauth_client_secret.as_ref(),
+        )
+    {
+        oauth2_providers.insert(
+            IntegrationProviderKind::Github,
+            Arc::new(GithubOAuth2Provider::new(
+                client_id.clone(),
+                SecretBox::new(Box::new(client_secret.clone())),
+                github_settings.required_oauth_scopes.clone(),
+            )),
+        );
+    }
+    if let Some(slack_settings) = settings.integrations.get("slack")
+        && let (Some(client_id), Some(client_secret)) = (
+            slack_settings.oauth_client_id.as_ref(),
+            slack_settings.oauth_client_secret.as_ref(),
+        )
+    {
+        oauth2_providers.insert(
+            IntegrationProviderKind::Slack,
+            Arc::new(SlackOAuth2Provider::new(
+                client_id.clone(),
+                SecretBox::new(Box::new(client_secret.clone())),
+                slack_settings.required_oauth_scopes.clone(),
+            )),
+        );
+    }
+    if let Some(todoist_settings) = settings.integrations.get("todoist")
+        && let (Some(client_id), Some(client_secret)) = (
+            todoist_settings.oauth_client_id.as_ref(),
+            todoist_settings.oauth_client_secret.as_ref(),
+        )
+    {
+        oauth2_providers.insert(
+            IntegrationProviderKind::Todoist,
+            Arc::new(TodoistOAuth2Provider::new(
+                client_id.clone(),
+                SecretBox::new(Box::new(client_secret.clone())),
+                todoist_settings.required_oauth_scopes.clone(),
+            )),
+        );
+    }
+    for (settings_key, provider_kind) in [
+        ("google_mail", IntegrationProviderKind::GoogleMail),
+        ("google_calendar", IntegrationProviderKind::GoogleCalendar),
+        ("google_drive", IntegrationProviderKind::GoogleDrive),
+    ] {
+        if let Some(google_settings) = settings.integrations.get(settings_key)
+            && let (Some(client_id), Some(client_secret)) = (
+                google_settings.oauth_client_id.as_ref(),
+                google_settings.oauth_client_secret.as_ref(),
+            )
+        {
+            oauth2_providers.insert(
+                provider_kind,
+                Arc::new(GoogleOAuth2Provider::new(
+                    provider_kind,
+                    client_id.clone(),
+                    SecretBox::new(Box::new(client_secret.clone())),
+                    google_settings.required_oauth_scopes.clone(),
+                )),
+            );
+        }
     }
 
     let token_encryption_key = settings

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -132,6 +132,7 @@ async fn main() -> std::io::Result<()> {
         )
         .expect("Failed to build an SmtpMailer"),
     ));
+    info!("Starting server on {}", settings.application.front_base_url);
     let webauthn = Arc::new(
         build_webauthn(&settings.application.front_base_url)
             .expect("Failed to build a Webauthn context"),

--- a/api/src/universal_inbox/integration_connection/service.rs
+++ b/api/src/universal_inbox/integration_connection/service.rs
@@ -33,7 +33,7 @@ use universal_inbox::{
 use crate::{
     integrations::oauth2::{
         AccessToken, AuthorizationCode, NangoService, PkceVerifier, RefreshToken,
-        provider::{OAuth2FlowService, OAuth2Provider},
+        provider::{OAuth2FlowService, OAuth2Provider, OAuthTokenResponse},
     },
     jobs::{
         UniversalInboxJob,
@@ -1423,22 +1423,23 @@ impl IntegrationConnectionService {
             ))
         })?;
 
-        // Collect providers that support migration
+        // Collect providers available for migration (any internal OAuth2 provider).
+        // Providers with `migration_url()` swap the Nango token for a fresh one via
+        // the provider's migration endpoint (Linear). Providers without it copy the
+        // Nango-held tokens directly into the encrypted local store.
         let migratable_providers: Vec<_> = self
             .oauth2_providers
             .iter()
-            .filter(|(kind, provider)| {
-                provider.migration_url().is_some() && provider_kind.is_none_or(|pk| pk == **kind)
-            })
+            .filter(|(kind, _)| provider_kind.is_none_or(|pk| pk == **kind))
             .collect();
 
         if migratable_providers.is_empty() {
-            info!("No providers with migration support found");
+            info!("No internal OAuth2 providers configured");
             return Ok((0, 0));
         }
 
         info!(
-            "Found {} provider(s) supporting token migration: {:?}",
+            "Found {} provider(s) to consider for token migration: {:?}",
             migratable_providers.len(),
             migratable_providers
                 .iter()
@@ -1476,13 +1477,10 @@ impl IntegrationConnectionService {
             for integration_connection in integration_connections {
                 let ic_provider_kind = integration_connection.provider.kind();
 
-                // Skip if this provider doesn't support migration
+                // Skip if no internal OAuth2 provider is configured for this provider kind
                 let Some(oauth2_provider) = self.oauth2_providers.get(&ic_provider_kind) else {
                     continue;
                 };
-                if oauth2_provider.migration_url().is_none() {
-                    continue;
-                }
                 // Skip if filtering by provider_kind and this doesn't match
                 if provider_kind.is_some() && provider_kind != Some(ic_provider_kind) {
                     continue;
@@ -1539,23 +1537,71 @@ impl IntegrationConnectionService {
                     }
                 };
 
-                // Step 2: Call migration endpoint
-                let token_response = match oauth2_flow_service
-                    .migrate_old_token(
-                        oauth2_provider.as_ref(),
-                        &nango_connection.credentials.access_token,
-                    )
-                    .await
-                {
-                    Ok(response) => response,
-                    Err(err) => {
-                        error!(
-                            "Failed to migrate token for connection {} (user {}): {err:?}",
-                            integration_connection.id, user.id
-                        );
-                        failed_count += 1;
-                        continue;
-                    }
+                // Step 2: Obtain token material. If the provider exposes a migration
+                // endpoint (Linear), swap the old token for a fresh pair. Otherwise,
+                // copy what Nango already holds — tokens were issued against the same
+                // client_id/client_secret, so they remain valid under the internal flow.
+                let (token_response, raw_response) = if oauth2_provider.migration_url().is_some() {
+                    let resp = match oauth2_flow_service
+                        .migrate_old_token(
+                            oauth2_provider.as_ref(),
+                            &nango_connection.credentials.access_token,
+                        )
+                        .await
+                    {
+                        Ok(response) => response,
+                        Err(err) => {
+                            error!(
+                                "Failed to migrate token for connection {} (user {}): {err:?}",
+                                integration_connection.id, user.id
+                            );
+                            failed_count += 1;
+                            continue;
+                        }
+                    };
+                    let raw = serde_json::to_value(resp.as_safe_token_response())
+                        .unwrap_or(serde_json::Value::Null);
+                    (resp, raw)
+                } else {
+                    let creds = &nango_connection.credentials;
+                    let expires_in = creds
+                        .expires_at
+                        .map(|at| (at - Utc::now()).num_seconds())
+                        .filter(|secs| *secs > 0);
+                    // Slack returns both a bot token (top-level `access_token`) and a user
+                    // token (`authed_user.access_token`). We request user scopes, so the user
+                    // token is the one we need; Nango stores the bot token at the top level.
+                    // Mirror the read-path special case in `fetch_access_token_from_nango`.
+                    let (access_token, refresh_token) =
+                        if ic_provider_kind == IntegrationProviderKind::Slack {
+                            let user_access_token = creds.raw["authed_user"]["access_token"]
+                                .as_str()
+                                .map(|t| AccessToken(t.to_string()))
+                                .unwrap_or_else(|| creds.access_token.clone());
+                            let user_refresh_token = creds.raw["authed_user"]["refresh_token"]
+                                .as_str()
+                                .map(|t| RefreshToken(t.to_string()))
+                                .or_else(|| creds.refresh_token.clone());
+                            (user_access_token, user_refresh_token)
+                        } else {
+                            (creds.access_token.clone(), creds.refresh_token.clone())
+                        };
+                    let resp = OAuthTokenResponse {
+                        access_token: SecretBox::new(Box::new(access_token)),
+                        refresh_token: refresh_token.map(|rt| SecretBox::new(Box::new(rt))),
+                        token_type: creds
+                            .raw
+                            .get("token_type")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string()),
+                        expires_in,
+                        extra: creds.raw.clone(),
+                    };
+                    // Preserve Nango's raw response so extract_registered_scopes and
+                    // provider-specific field readers (Slack authed_user.*, etc.) keep working,
+                    // but strip plaintext token material before it hits the raw_response column.
+                    let sanitized_raw = oauth2_provider.sanitize_raw_response(&creds.raw);
+                    (resp, sanitized_raw)
                 };
 
                 // Step 3: Encrypt and store (bind ciphertext to this connection via AAD)
@@ -1597,9 +1643,6 @@ impl IntegrationConnectionService {
                         continue;
                     }
                 };
-
-                let raw_response = serde_json::to_value(token_response.as_safe_token_response())
-                    .unwrap_or(serde_json::Value::Null);
 
                 let mut store_transaction = self.begin().await.context(format!(
                     "Failed to create transaction for connection {} (user {})",
@@ -1920,10 +1963,18 @@ impl IntegrationConnectionService {
 
         let mut auth_request = client.authorize_url(CsrfToken::new_random);
 
-        // Add scopes as an extra param (some providers use non-standard separators)
+        // Add scopes as an extra param (each provider controls delimiter & param name)
         let scopes = provider.required_scopes();
         if !scopes.is_empty() {
-            auth_request = auth_request.add_extra_param("scope", scopes.join(","));
+            auth_request = auth_request.add_extra_param(
+                provider.scope_param_name(),
+                scopes.join(provider.scope_delimiter()),
+            );
+        }
+
+        // Provider-specific extra authorize params (e.g. Google's access_type=offline)
+        for (key, value) in provider.extra_authorize_params() {
+            auth_request = auth_request.add_extra_param(key, value);
         }
 
         // Add PKCE if supported
@@ -2055,6 +2106,7 @@ impl IntegrationConnectionService {
             )));
         }
 
+        let stored_raw_response = provider.sanitize_raw_response(&raw_response);
         self.repository
             .store_oauth_credential(
                 executor,
@@ -2062,9 +2114,29 @@ impl IntegrationConnectionService {
                 encrypted_access_token,
                 encrypted_refresh_token,
                 expires_at,
-                raw_response,
+                stored_raw_response,
             )
             .await?;
+
+        if let Some(provider_user_id) = provider.extract_provider_user_id(&raw_response) {
+            self.repository
+                .update_integration_connection_provider_user_id(
+                    executor,
+                    state_data.integration_connection_id,
+                    Some(provider_user_id),
+                )
+                .await?;
+        }
+
+        if let Some(provider_context) = provider.extract_provider_context(&raw_response) {
+            self.repository
+                .update_integration_connection_context(
+                    executor,
+                    state_data.integration_connection_id,
+                    Some(provider_context),
+                )
+                .await?;
+        }
 
         self.update_integration_connection_status(
             executor,

--- a/web/src/components/footer.rs
+++ b/web/src/components/footer.rs
@@ -259,14 +259,14 @@ pub fn IntegrationConnectionsStatus(
 
 #[component]
 pub fn IntegrationConnectionStatus(
-    connection: IntegrationConnection,
-    config: IntegrationProviderStaticConfig,
+    connection: ReadSignal<IntegrationConnection>,
+    config: ReadSignal<IntegrationProviderStaticConfig>,
     icon_class: Option<&'static str>,
 ) -> Element {
     let icon_style = icon_class.unwrap_or("w-4 h-4");
-    let provider_kind = connection.provider.kind();
-    let connection_is_syncing = connection.is_syncing();
-    let (connection_style, tooltip_style, tooltip) = use_memo(move || match &connection {
+    let provider_kind = connection().provider.kind();
+    let connection_is_syncing = connection().is_syncing();
+    let (connection_style, tooltip_style, tooltip) = use_memo(move || match connection() {
         IntegrationConnection {
             status: ConnectionStatus::Validated,
             last_notifications_sync_started_at: notifs_started_at,
@@ -275,7 +275,7 @@ pub fn IntegrationConnectionStatus(
             last_tasks_sync_failure_message: None,
             ..
         } => {
-            if connection.has_oauth_scopes(&config.required_oauth_scopes) {
+            if connection().has_oauth_scopes(&config().required_oauth_scopes) {
                 let started_at = match (notifs_started_at, tasks_started_at) {
                     (Some(notifs_started_at), Some(tasks_started_at)) => {
                         Some(notifs_started_at.max(tasks_started_at))


### PR DESCRIPTION
## Summary

- Extend the internal OAuth2 stack (previously Linear-only) to **GitHub, Slack, Todoist, Google Mail, Google Calendar, and Google Drive**. Each provider is auto-enabled once its `oauth_client_id` / `oauth_client_secret` are configured; otherwise the existing Nango flow continues to be used (automatic fallback, no forced migration).
- Add provider-quirk hooks to the `OAuth2Provider` trait — `scope_delimiter`, `scope_param_name`, `extra_authorize_params`, `token_request_headers`, `parse_token_response` — so each provider can handle its idiosyncrasies (Google's `access_type=offline` / `prompt=consent`, Slack v2's `authed_user.access_token`, GitHub's `Accept: application/json`).
- Extend the existing `just api migrate-oauth-tokens` command with a direct-copy path for providers without a dedicated migration endpoint. Nango-held access/refresh tokens are read, encrypted (AES-256-GCM, connection-scoped AAD), and stored in `oauth_credential`. This works because Nango and the internal flow share the same OAuth app credentials — issued tokens remain valid. Linear keeps using its `migrate_old_token` endpoint.

## Touch list

- `api/src/integrations/oauth2/provider.rs` — trait hooks + wiring in `exchange_code_for_token` / `refresh_access_token` / `migrate_old_token`.
- `api/src/integrations/github/oauth.rs`, `slack_oauth.rs`, `todoist_oauth.rs`, `google_oauth.rs` — six new provider impls (one shared `GoogleOAuth2Provider` for Mail/Calendar/Drive).
- `api/src/universal_inbox/integration_connection/service.rs` — scope/param hooks in `start_oauth_authorization`, direct-copy branch in `migrate_nango_tokens`.
- `api/src/lib.rs` — register the six new providers conditionally on config.
- `api/config/default.toml` — commented `oauth_client_id` / `oauth_client_secret` stubs under each integration.
- `CHANGELOG.md` — Unreleased entry.

No DB migration and no frontend changes were required — `routes/config.rs` already switches the frontend to the internal flow as soon as `oauth_client_id` is set.

## Test plan

- [x] `just check` — clippy + compile clean on workspace.
- [x] `cargo test --lib integrations::github::oauth` — 7 tests pass.
- [x] `cargo test --lib integrations::slack_oauth` — 10 tests pass (including Slack v2 `authed_user.access_token` parsing and team-id context extraction).
- [x] `cargo test --lib integrations::todoist_oauth` — 5 tests pass.
- [x] `cargo test --lib integrations::google_oauth` — 7 tests pass (including space-delimited scope extraction and `access_type=offline` / `prompt=consent` params).
- [x] `cargo test --lib integrations::linear::oauth` / `integrations::oauth2` — regression tests pass.
- [ ] Manual end-to-end per provider: configure `oauth_client_id` / `oauth_client_secret`, connect fresh via `/api/oauth/authorize/<id>`, verify `oauth_credential` row exists.
- [ ] Manual migration: with a test user holding Nango-backed connections, run `just api migrate-oauth-tokens --dry-run` then the real run; confirm sync still works against copied tokens.
- [ ] Manual fallback check: leave `oauth_client_id` blank for one provider and verify the Nango flow still works unchanged.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/universal-inbox/universal-inbox/pull/161" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth now supports internal handling for GitHub, Slack, Todoist, Google Mail, Google Calendar, and Google Drive.
  * Provider-specific authorize params and scope handling (including PKCE behavior) are now respected.

* **Migration**
  * Improved migration of existing OAuth connections with better token extraction (including Slack-specific handling) and sanitized stored token data; existing Nango fallback remains when credentials are absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->