### PR TITLE
fix: Persist MCP sessions to Redis for multi-pod restore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6040,9 +6040,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.2.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba6b9d2f0efe2258b23767f1f9e0054cfbcac9c2d6f81a031214143096d7864f"
+checksum = "e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6072,11 +6072,10 @@ dependencies = [
 [[package]]
 name = "rmcp-actix-web"
 version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85f125d3ab16dad1f7fb9542e3ebe93f25eefee847a03692b7eb37134104cf3d"
 dependencies = [
  "actix-web",
  "async-stream",
+ "async-trait",
  "bon",
  "futures",
  "rmcp",
@@ -6089,9 +6088,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.2.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9d95d7ed26ad8306352b0d5f05b593222b272790564589790d210aa15caa9e"
+checksum = "7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,3 +101,8 @@ inherits = "dev"
 inherits = "dev"
 
 [patch.crates-io]
+# Vendored copy of rmcp-actix-web 0.12.3 patched to wire up rmcp 1.6's
+# `SessionStore` for cross-instance MCP session restore (multi-pod deployments).
+# Upstream's `handle_get`/`handle_post` reject unknown sessions with 401 instead
+# of consulting the configured store. See api/vendor/rmcp-actix-web/.
+rmcp-actix-web = { path = "api/vendor/rmcp-actix-web" }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -106,7 +106,7 @@ reqwest_v013 = { package = "reqwest", version = "0.13", default-features = false
 reqwest-middleware = { version = "0.5.0", features = ["json", "form"] }
 reqwest-tracing = { version = "0.7.0", features = ["opentelemetry_0_31"] }
 rpassword = "5"
-rmcp = { version = "1.2.0", features = [
+rmcp = { version = "1.6", features = [
   "transport-streamable-http-server",
   "transport-streamable-http-server-session",
 ] }

--- a/api/config/default.toml
+++ b/api/config/default.toml
@@ -95,6 +95,12 @@ dependencies_log_level = "error"
 # website_id = "CRISP_WEBSITE_ID"
 # identity_verification_secret_key = "CRISP_SECRET_KEY"
 
+# Redis-backed MCP session store. Persists each session's `initialize`
+# parameters so a follow-up request landing on a different pod can transparently
+# restore the session. Always enabled; only the TTL is configurable.
+[application.mcp_session_store]
+ttl_seconds = 86400
+
 [database]
 host = "127.0.0.1"
 port = 5432

--- a/api/src/configuration.rs
+++ b/api/src/configuration.rs
@@ -53,6 +53,20 @@ pub struct ApplicationSettings {
     pub version: Option<String>,
     pub dry_run: bool,
     pub chat_support: Option<ChatSupportSettings>,
+    pub mcp_session_store: McpSessionStoreSettings,
+}
+
+/// Configuration for the Redis-backed MCP session store.
+///
+/// The store persists each session's `initialize` parameters so that any pod
+/// behind the load balancer can transparently restore a session that was
+/// initialised on a different pod. It is always wired up — only the TTL is
+/// configurable.
+#[derive(Deserialize, Clone, Debug)]
+pub struct McpSessionStoreSettings {
+    /// TTL applied to persisted session state. Should comfortably exceed
+    /// expected client idle time.
+    pub ttl_seconds: u64,
 }
 
 /// Deserialize a list of strings from either a TOML array (`["a", "b"]`)

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -161,11 +161,15 @@ pub async fn run_server(
     };
 
     let storage_data = web::Data::new(redis_storage.clone());
-    let cache_data = web::Data::new(
-        Cache::new(settings.redis.connection_string())
-            .await
-            .expect("Failed to create cache"),
-    );
+    let cache = Cache::new(settings.redis.connection_string())
+        .await
+        .expect("Failed to create cache");
+    let mcp_session_store: Arc<dyn rmcp::transport::streamable_http_server::session::SessionStore> =
+        Arc::new(mcp::RedisSessionStore::new(
+            cache.connection_manager.clone(),
+            settings.application.mcp_session_store.ttl_seconds,
+        ));
+    let cache_data = web::Data::new(cache);
     let mcp_extra_allowed_origins = settings
         .application
         .security
@@ -181,6 +185,7 @@ pub async fn run_server(
         notification_service.clone(),
         task_service.clone(),
         redis_storage.clone(),
+        mcp_session_store,
     );
     let oauth2_rate_limiter = routes::oauth2::build_rate_limiter();
     let mcp_rate_limiter = mcp::build_rate_limiter();

--- a/api/src/mcp/mod.rs
+++ b/api/src/mcp/mod.rs
@@ -24,7 +24,7 @@ use rmcp::{
     },
     service::{RequestContext, RoleServer},
     tool, tool_handler, tool_router,
-    transport::streamable_http_server::session::local::LocalSessionManager,
+    transport::streamable_http_server::session::{SessionStore, local::LocalSessionManager},
 };
 use rmcp_actix_web::transport::StreamableHttpService;
 use tokio::sync::RwLock;
@@ -48,7 +48,10 @@ use crate::{
     utils::jwt::Claims,
 };
 
+pub mod session_store;
 pub mod tools;
+
+pub use session_store::RedisSessionStore;
 
 const SERVER_NAME: &str = "universal-inbox";
 const SERVER_TITLE: &str = "Universal Inbox";
@@ -63,10 +66,15 @@ pub type McpRateLimiter = RateLimiter<UserId, DefaultKeyedStateStore<UserId>, De
 /// Build the `StreamableHttpService` once so the `LocalSessionManager` is shared
 /// across all Actix-web worker threads.  Call this **before** `HttpServer::new`
 /// and clone the returned service into each worker via `scope()`.
+///
+/// The `session_store` is the cross-pod shared state: when a request lands on
+/// a pod whose `LocalSessionManager` does not know the session, the patched
+/// `rmcp-actix-web` consults the store and replays the `initialize` handshake.
 pub fn build_http_service(
     notification_service: Arc<RwLock<NotificationService>>,
     task_service: Arc<RwLock<TaskService>>,
     job_storage: RedisStorage<UniversalInboxJob>,
+    session_store: Arc<dyn SessionStore>,
 ) -> StreamableHttpService<UniversalInboxMcpServer, LocalSessionManager> {
     let services = McpServices {
         notification_service,
@@ -80,6 +88,7 @@ pub fn build_http_service(
         }))
         .session_manager(Arc::new(LocalSessionManager::default()))
         .stateful_mode(true)
+        .session_store(session_store)
         .on_request_fn(|http_req, extensions| {
             if let Some(authenticated) = http_req.extensions().get::<Authenticated<Claims>>() {
                 extensions.insert(authenticated.clone());
@@ -335,6 +344,10 @@ where
 #[derive(Clone)]
 pub struct UniversalInboxMcpServer {
     services: McpServices,
+    // Consumed by `#[tool_handler]`'s macro-generated `call_tool` impl below;
+    // the rmcp 1.6 macro expansion no longer references the field by name,
+    // so static analysis does not see the read.
+    #[allow(dead_code)]
     tool_router: ToolRouter<Self>,
 }
 

--- a/api/src/mcp/session_store.rs
+++ b/api/src/mcp/session_store.rs
@@ -1,0 +1,69 @@
+//! Redis-backed [`SessionStore`] for cross-pod MCP session restore.
+//!
+//! When the API runs as multiple replicas behind a load balancer, each pod
+//! holds its own [`LocalSessionManager`] and so does not know about sessions
+//! that initialised on a different pod. This store persists each session's
+//! `initialize` parameters (the [`SessionState`]) to shared Redis so the
+//! upstream rmcp transport can transparently replay the handshake on whichever
+//! pod a follow-up request lands on.
+//!
+//! [`LocalSessionManager`]: rmcp::transport::streamable_http_server::session::local::LocalSessionManager
+
+use async_trait::async_trait;
+use redis::{AsyncCommands, aio::ConnectionManager};
+use rmcp::transport::streamable_http_server::session::{
+    SessionState, SessionStore, SessionStoreError,
+};
+
+const NAMESPACE: &str = "universal-inbox:mcp:session:";
+
+#[derive(Clone)]
+pub struct RedisSessionStore {
+    conn: ConnectionManager,
+    ttl_seconds: u64,
+}
+
+impl RedisSessionStore {
+    pub fn new(conn: ConnectionManager, ttl_seconds: u64) -> Self {
+        Self { conn, ttl_seconds }
+    }
+
+    fn key(id: &str) -> String {
+        format!("{NAMESPACE}{id}")
+    }
+}
+
+#[async_trait]
+impl SessionStore for RedisSessionStore {
+    async fn load(&self, session_id: &str) -> Result<Option<SessionState>, SessionStoreError> {
+        let mut conn = self.conn.clone();
+        let raw: Option<String> = conn
+            .get(Self::key(session_id))
+            .await
+            .map_err(|e| Box::new(e) as SessionStoreError)?;
+        match raw {
+            None => Ok(None),
+            Some(s) => serde_json::from_str::<SessionState>(&s)
+                .map(Some)
+                .map_err(|e| Box::new(e) as SessionStoreError),
+        }
+    }
+
+    async fn store(&self, session_id: &str, state: &SessionState) -> Result<(), SessionStoreError> {
+        let mut conn = self.conn.clone();
+        let payload = serde_json::to_string(state).map_err(|e| Box::new(e) as SessionStoreError)?;
+        conn.set_ex::<_, _, ()>(Self::key(session_id), payload, self.ttl_seconds)
+            .await
+            .map_err(|e| Box::new(e) as SessionStoreError)?;
+        Ok(())
+    }
+
+    async fn delete(&self, session_id: &str) -> Result<(), SessionStoreError> {
+        let mut conn = self.conn.clone();
+        let _: () = conn
+            .del(Self::key(session_id))
+            .await
+            .map_err(|e| Box::new(e) as SessionStoreError)?;
+        Ok(())
+    }
+}

--- a/api/tests/api/main.rs
+++ b/api/tests/api/main.rs
@@ -14,6 +14,7 @@ mod test_integration_connections;
 mod test_linear_notifications;
 mod test_linear_tasks;
 mod test_mcp;
+mod test_mcp_session_store;
 mod test_misc;
 mod test_multi_task_manager;
 mod test_notifications;

--- a/api/tests/api/test_mcp_session_store.rs
+++ b/api/tests/api/test_mcp_session_store.rs
@@ -1,0 +1,95 @@
+use redis::AsyncCommands;
+use rmcp::{
+    model::{ClientCapabilities, Implementation, InitializeRequestParams},
+    transport::streamable_http_server::session::{SessionState, SessionStore},
+};
+use rstest::*;
+use uuid::Uuid;
+
+use universal_inbox_api::mcp::RedisSessionStore;
+
+use crate::helpers::{TestedApp, tested_app};
+
+fn fresh_session_id() -> String {
+    format!("test-session-{}", Uuid::new_v4())
+}
+
+fn sample_state() -> SessionState {
+    SessionState::new(InitializeRequestParams::new(
+        ClientCapabilities::default(),
+        Implementation::new("test-client", "1.0.0"),
+    ))
+}
+
+#[rstest]
+#[tokio::test]
+async fn store_then_load_round_trips(#[future] tested_app: TestedApp) {
+    let app = tested_app.await;
+    let store = RedisSessionStore::new(app.cache.connection_manager.clone(), 60);
+    let id = fresh_session_id();
+    let state = sample_state();
+
+    store.store(&id, &state).await.expect("store failed");
+
+    let loaded = store.load(&id).await.expect("load failed");
+    let loaded = loaded.expect("expected Some(SessionState)");
+    assert_eq!(
+        loaded.initialize_params.client_info.name,
+        state.initialize_params.client_info.name
+    );
+    assert_eq!(
+        loaded.initialize_params.client_info.version,
+        state.initialize_params.client_info.version
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn load_returns_none_for_unknown_session(#[future] tested_app: TestedApp) {
+    let app = tested_app.await;
+    let store = RedisSessionStore::new(app.cache.connection_manager.clone(), 60);
+
+    let loaded = store.load(&fresh_session_id()).await.expect("load failed");
+    assert!(loaded.is_none());
+}
+
+#[rstest]
+#[tokio::test]
+async fn delete_removes_persisted_session(#[future] tested_app: TestedApp) {
+    let app = tested_app.await;
+    let store = RedisSessionStore::new(app.cache.connection_manager.clone(), 60);
+    let id = fresh_session_id();
+
+    store
+        .store(&id, &sample_state())
+        .await
+        .expect("store failed");
+    store.delete(&id).await.expect("delete failed");
+
+    let loaded = store.load(&id).await.expect("load failed");
+    assert!(loaded.is_none());
+}
+
+#[rstest]
+#[tokio::test]
+async fn store_applies_configured_ttl(#[future] tested_app: TestedApp) {
+    let app = tested_app.await;
+    let configured_ttl: u64 = 600;
+    let store = RedisSessionStore::new(app.cache.connection_manager.clone(), configured_ttl);
+    let id = fresh_session_id();
+    let key = format!("universal-inbox:mcp:session:{id}");
+
+    store
+        .store(&id, &sample_state())
+        .await
+        .expect("store failed");
+
+    let mut conn = app.cache.connection_manager.clone();
+    let ttl: i64 = conn.ttl(&key).await.expect("TTL query failed");
+    assert!(
+        ttl > 0 && ttl <= configured_ttl as i64,
+        "expected TTL within (0, {configured_ttl}], got {ttl}"
+    );
+
+    let _: () = conn.del(&key).await.unwrap_or(());
+}

--- a/api/vendor/rmcp-actix-web/.gitignore
+++ b/api/vendor/rmcp-actix-web/.gitignore
@@ -1,0 +1,9 @@
+/target
+rust-sdk/
+node_modules/
+*.egg-info/
+__pycache__/
+.pytest_cache/
+
+# Claude Code superpowers
+docs/plans/*.md

--- a/api/vendor/rmcp-actix-web/.gitlab-ci.yml
+++ b/api/vendor/rmcp-actix-web/.gitlab-ci.yml
@@ -1,0 +1,139 @@
+# GitLab CI configuration for rmcp-actix-web
+
+# Include CI configuration files
+include:
+  - local: '.gitlab/ci/common.gitlab-ci.yml'
+  - local: '.gitlab/ci/devcontainer.gitlab-ci.yml'
+  - local: '.gitlab/ci/images.gitlab-ci.yml'
+  - local: '.gitlab/ci/rust.gitlab-ci.yml'
+
+# Global variables for package versions
+variables:
+  IMAGE_BUILD_FORCE:
+    description: "Build images even when there are no changes."
+    options:
+      - "false"
+      - "all"
+      - "rust-x86_64-unknown-linux-gnu"
+    value: "false"
+  IMAGE_PUSH_FORCE:
+    description: "Push images even when there are no changes."
+    options:
+      - "false"
+      - "all"
+      - "rust-x86_64-unknown-linux-gnu"
+    value: "false"
+  # renovate: datasource=node-version depName=node versioning=node
+  NODE_VERSION: "20.11.1"
+
+# Workflow rules for automatic pipeline cancellation
+workflow:
+  auto_cancel:
+    on_new_commit: interruptible
+    on_job_failure: none
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    # Skip branch pipeline for release commits (tag pipeline will run instead)
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_COMMIT_TITLE =~ /^chore\(release\):/
+      when: never
+    # Disable auto-cancel for release pipelines
+    - if: '$RELEASE_ENABLED == "true"'
+      auto_cancel:
+        on_new_commit: none
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    - if: $CI_COMMIT_TAG
+
+# Semantic release job template - common setup for semantic-release jobs
+.semantic-release-template:
+  image: rust:1.94.0@sha256:7e322aa1b876cbb977e0df46812af6c4e8be2efbfb2ce3712c28a93ba2968726
+  variables:
+    # renovate: datasource=npm depName=semantic-release versioning=npm
+    SEMANTIC_RELEASE_VERSION: "21.0.7"
+    # renovate: datasource=npm depName=@semantic-release/changelog versioning=npm
+    SEMANTIC_RELEASE_CHANGELOG_VERSION: "6.0.3"
+    # renovate: datasource=npm depName=@semantic-release/git versioning=npm
+    SEMANTIC_RELEASE_GIT_VERSION: "10.0.1"
+    # renovate: datasource=npm depName=@semantic-release/gitlab versioning=npm
+    SEMANTIC_RELEASE_GITLAB_VERSION: "12.1.1"
+    # renovate: datasource=npm depName=@semantic-release/exec versioning=npm
+    SEMANTIC_RELEASE_EXEC_VERSION: "6.0.3"
+    # renovate: datasource=npm depName=conventional-changelog-conventionalcommits versioning=npm
+    CONVENTIONAL_CHANGELOG_CONVENTIONALCOMMITS_VERSION: "7.0.2"
+    # renovate: datasource=github-releases depName=semantic-release-cargo/semantic-release-cargo extractVersionTemplate="^v(?<version>.*)$"
+    SEMANTIC_RELEASE_CARGO_VERSION: "2.4.44"
+  before_script:
+    # Install Node.js in Rust image
+    - apt-get update -qq && apt-get install -y -qq curl
+    - curl -fsSL https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz | tar -xJ -C /usr/local --strip-components=1
+    - node --version
+    - npm --version
+    # Install semantic-release and plugins
+    - npm install -g semantic-release@${SEMANTIC_RELEASE_VERSION} @semantic-release/changelog@${SEMANTIC_RELEASE_CHANGELOG_VERSION} @semantic-release/git@${SEMANTIC_RELEASE_GIT_VERSION} @semantic-release/gitlab@${SEMANTIC_RELEASE_GITLAB_VERSION} @semantic-release/exec@${SEMANTIC_RELEASE_EXEC_VERSION} conventional-changelog-conventionalcommits@${CONVENTIONAL_CHANGELOG_CONVENTIONALCOMMITS_VERSION}
+    # Install semantic-release-cargo static binary
+    - curl -L https://github.com/semantic-release-cargo/semantic-release-cargo/releases/download/v${SEMANTIC_RELEASE_CARGO_VERSION}/semantic-release-cargo-x86_64-unknown-linux-musl -o /usr/local/bin/semantic-release-cargo
+    - chmod +x /usr/local/bin/semantic-release-cargo
+    - semantic-release-cargo --version
+  interruptible: true
+
+# Pipeline stages
+stages:
+  - build
+  - test
+  - lint
+  - docs
+  - examples
+  - integration
+  - release
+
+# Semantic release config lint job - validate semantic-release configuration
+semantic-release-lint:
+  extends: .semantic-release-template
+  stage: lint
+  script:
+    - semantic-release --dry-run --no-ci
+
+# Commit lint job - check commit message format
+commitlint:
+  image: node:24.14.0@sha256:3a09aa6354567619221ef6c45a5051b671f953f0a1924d1f819ffb236e520e6b
+  stage: lint
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "push"'
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+    - if: '$CI_COMMIT_TAG'
+      when: never
+  variables:
+    GIT_FETCH_EXTRA_FLAGS: '+refs/heads/main:refs/remotes/origin/main'
+    # renovate: datasource=npm depName=@commitlint/cli versioning=npm
+    COMMITLINT_CLI_VERSION: "17.6.1"
+    # renovate: datasource=npm depName=@commitlint/config-conventional versioning=npm
+    COMMITLINT_CONFIG_VERSION: "17.6.1"
+  before_script:
+    - npm install -g @commitlint/cli@${COMMITLINT_CLI_VERSION} @commitlint/config-conventional@${COMMITLINT_CONFIG_VERSION}
+  script:
+    - |
+      echo "module.exports = {
+        extends: ['@commitlint/config-conventional'],
+        rules: {
+          'header-max-length': [2, 'always', 150],
+        },
+      }" > ./commitlint.config.js
+      commitlint --from=$(git merge-base origin/main HEAD) --to=$CI_COMMIT_SHA
+  interruptible: true
+
+# Semantic release job - automated versioning and releases
+semantic-release:
+  extends: .semantic-release-template
+  stage: release
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $RELEASE_ENABLED == "true"'
+    - if: '$CI_PIPELINE_SOURCE == "web" && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $RELEASE_ENABLED == "true"'
+  variables:
+    GIT_FETCH_EXTRA_FLAGS: '+refs/heads/main:refs/remotes/origin/main'
+  before_script:
+    - !reference [.semantic-release-template, before_script]
+    # Configure git
+    - git config user.name "${GITLAB_USER_NAME}"
+    - git config user.email "${GITLAB_USER_EMAIL}"
+  script:
+    - semantic-release
+  interruptible: false

--- a/api/vendor/rmcp-actix-web/.releaserc.json
+++ b/api/vendor/rmcp-actix-web/.releaserc.json
@@ -1,0 +1,73 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "angular",
+        "releaseRules": [
+          { "breaking": true, "release": "minor" },
+          { "type": "docs", "scope": "README", "release": "patch" },
+          { "type": "fix", "release": "patch" },
+          { "type": "refactor", "release": "patch" },
+          { "type": "chore", "scope": "deps", "release": "patch" },
+          { "type": "feat", "release": "minor" }
+        ],
+        "parserOpts": {
+          "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES"]
+        }
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits",
+        "presetConfig": {
+          "types": [
+            {
+              "type": "feat",
+              "section": "Features",
+              "hidden": false
+            },
+            {
+              "type": "fix",
+              "section": "Bug Fixes",
+              "hidden": false
+            },
+            {
+              "type": "chore",
+              "scope": "deps",
+              "section": "Miscellaneous Chores",
+              "hidden": false
+            }
+          ]
+        }
+      }
+    ],
+    "@semantic-release/changelog",
+    [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "semantic-release-cargo prepare ${nextRelease.version}",
+        "publishCmd": "semantic-release-cargo --log-level=trace publish"
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": [
+          "CHANGELOG.md",
+          "Cargo.toml",
+          "Cargo.lock"
+        ],
+        "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
+      }
+    ],
+    [
+      "@semantic-release/gitlab",
+      {
+        "assets": []
+      }
+    ]
+  ]
+}

--- a/api/vendor/rmcp-actix-web/CHANGELOG.md
+++ b/api/vendor/rmcp-actix-web/CHANGELOG.md
@@ -1,0 +1,595 @@
+## [0.12.3](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.12.2...v0.12.3) (2026-03-16)
+
+
+### Miscellaneous Chores
+
+* **deps:** update registry.gitlab.com/lx-industries/rmcp-actix-web/images/rust:1.94.0-x86_64-unknown-linux-gnu docker digest to d4f1ccf ([57e1324](https://gitlab.com/lx-industries/rmcp-actix-web/commit/57e1324b923db192d02b9911641fffaa84904b9b))
+* **deps:** update rust crate bon to v3.9.1 ([163f114](https://gitlab.com/lx-industries/rmcp-actix-web/commit/163f11438467abdbe1274fcfd3171f10d15abdfe))
+* **deps:** update rust crate rmcp to v1.2.0 ([c53d581](https://gitlab.com/lx-industries/rmcp-actix-web/commit/c53d58113523e259fff691693e0b0b625572b96d))
+* **deps:** update rust crate tracing-subscriber to v0.3.23 ([b95da30](https://gitlab.com/lx-industries/rmcp-actix-web/commit/b95da30394c4c82ffdcfd9e0d732b11efa77fe97))
+* **deps:** update rust:1.94.0 docker digest to 7e322aa ([de7e17c](https://gitlab.com/lx-industries/rmcp-actix-web/commit/de7e17c9433761356f823bd2eee74f9f5fb5d5ac))
+
+## [0.12.2](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.12.1...v0.12.2) (2026-03-09)
+
+
+### Miscellaneous Chores
+
+* **deps:** update docker docker tag to v29.3.0 ([a2644fd](https://gitlab.com/lx-industries/rmcp-actix-web/commit/a2644fde4a46c8146d65410d52176969798d06bd))
+* **deps:** update docker:29.3.0-dind docker digest to 1ba1844 ([f4dc18a](https://gitlab.com/lx-industries/rmcp-actix-web/commit/f4dc18a96a0eedee5df0d0c396bd86e56faf782a))
+* **deps:** update registry.gitlab.com/lx-industries/rmcp-actix-web/images/rust docker tag to v1.94.0 ([d80ad78](https://gitlab.com/lx-industries/rmcp-actix-web/commit/d80ad78a794328f767f7c1843fa2f4eeab315404))
+* **deps:** update registry.gitlab.com/lx-industries/rmcp-actix-web/images/rust:1.93.1-x86_64-unknown-linux-gnu docker digest to 51544c2 ([51aafa8](https://gitlab.com/lx-industries/rmcp-actix-web/commit/51aafa8083145003cbe29a65938e01a8006c6359))
+* **deps:** update rust crate rmcp to v1.1.1 ([6eb406f](https://gitlab.com/lx-industries/rmcp-actix-web/commit/6eb406f53ea423ce524013670f8ff6b2559966db))
+* **deps:** update rust docker tag to v1.94.0 ([04bcccb](https://gitlab.com/lx-industries/rmcp-actix-web/commit/04bcccbccc7fa0186c215d08798711c61020b74f))
+
+## [0.12.1](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.12.0...v0.12.1) (2026-03-05)
+
+
+### Miscellaneous Chores
+
+* **deps:** update docker:29.2.1-dind docker digest to 68f6d9a ([8fe2d7f](https://gitlab.com/lx-industries/rmcp-actix-web/commit/8fe2d7f0761ab6261e7fe1a5eee4be0201adabea))
+* **deps:** update node.js to v24.14.0 ([b38e985](https://gitlab.com/lx-industries/rmcp-actix-web/commit/b38e9857c943885aa737807a2788fde51b244440))
+* **deps:** update rust crate actix-web to v4.13.0 ([78c46fe](https://gitlab.com/lx-industries/rmcp-actix-web/commit/78c46fe7825df252896a512fc5f17e9190f606f9))
+* **deps:** update rust crate anyhow to v1.0.102 ([695f5e7](https://gitlab.com/lx-industries/rmcp-actix-web/commit/695f5e7923efff174e5259da67b254d18841d81e))
+* **deps:** update rust crate chrono to v0.4.44 ([9a45eeb](https://gitlab.com/lx-industries/rmcp-actix-web/commit/9a45eeb6ff940210afc5c7a5082da2d60288972c))
+* **deps:** update rust crate futures to v0.3.32 ([77a10f8](https://gitlab.com/lx-industries/rmcp-actix-web/commit/77a10f89502d8e65c0d4a50e8083a443e4158acb))
+* **deps:** update rust crate rmcp to v1 ([37f780c](https://gitlab.com/lx-industries/rmcp-actix-web/commit/37f780c04085e2cf0240d9328c5b86be31ae596e))
+* **deps:** update rust crate tokio to v1.50.0 ([21388ef](https://gitlab.com/lx-industries/rmcp-actix-web/commit/21388ef5fe9a01a6a6d5175cfb2953e964429375))
+* **deps:** update rust:1.93.1 docker digest to ecbe59a ([74d83f7](https://gitlab.com/lx-industries/rmcp-actix-web/commit/74d83f7318bce17a4193c3b5eec6644b1b0ca619))
+
+## [0.12.0](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.11.1...v0.12.0) (2026-03-03)
+
+
+### Features
+
+* add devcontainer setup with firewall and justfile ([a11ced3](https://gitlab.com/lx-industries/rmcp-actix-web/commit/a11ced38b0ceab0a056f5208ea435929c11f07d2))
+
+
+### Miscellaneous Chores
+
+* **deps:** update rust crate rmcp to 0.17.0 ([4ab88b6](https://gitlab.com/lx-industries/rmcp-actix-web/commit/4ab88b6b3567ae92bf767e3606540a39c9fbb758))
+
+## [0.11.1](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.11.0...v0.11.1) (2026-02-13)
+
+
+### Bug Fixes
+
+* **ci:** add IMAGE_BUILD_FORCE and IMAGE_PUSH_FORCE pipeline variables ([65a71de](https://gitlab.com/lx-industries/rmcp-actix-web/commit/65a71de59a79bcccdda5745b3514daa1dbf93a1a))
+* **ci:** add renovate tracking comments to semantic-release and commitlint versions ([bf6754b](https://gitlab.com/lx-industries/rmcp-actix-web/commit/bf6754bf88cf380983f43b1308704722e58b5a65))
+* **ci:** hardcode registry path and update Rust image digest ([b7c0480](https://gitlab.com/lx-industries/rmcp-actix-web/commit/b7c0480e54fc5ae542f033f5c59f2ecb417ddb0c))
+* **ci:** use extends instead of YAML anchors for semantic-release jobs ([2e8531b](https://gitlab.com/lx-industries/rmcp-actix-web/commit/2e8531bfd45c94e26ecbd5cf24cfbceda11a9327))
+* **ci:** wire sccache variables into Rust jobs via extends ([04772f2](https://gitlab.com/lx-industries/rmcp-actix-web/commit/04772f23c2993659c0280aa985ed1ab3d890366a))
+
+
+### Miscellaneous Chores
+
+* **deps:** update docker docker tag to v29 ([0928de0](https://gitlab.com/lx-industries/rmcp-actix-web/commit/0928de013101dea0c450fff2b85bf816213b4a56))
+* **deps:** update node.js to 1de022d ([ec36a68](https://gitlab.com/lx-industries/rmcp-actix-web/commit/ec36a68d8c8594721810a3788ea5b445ab29ac58))
+* **deps:** update node.js to v24.13.1 ([f71e2c7](https://gitlab.com/lx-industries/rmcp-actix-web/commit/f71e2c732032b5ad1cf6625b094ee03dcd75a1bf))
+* **deps:** update registry.gitlab.com/lx-industries/rmcp-actix-web/images/rust docker tag to v1.93.1 ([bb61277](https://gitlab.com/lx-industries/rmcp-actix-web/commit/bb612773b6462697c4884a3df425a512ddad2b96))
+* **deps:** update registry.gitlab.com/lx-industries/rmcp-actix-web/images/rust:1.93.0-x86_64-unknown-linux-gnu docker digest to 0b2b733 ([1a5b61b](https://gitlab.com/lx-industries/rmcp-actix-web/commit/1a5b61b49ab1bfd0b4ee4b57ae3511b15cf0bd8a))
+* **deps:** update rust crate anyhow to v1.0.101 ([f24e11e](https://gitlab.com/lx-industries/rmcp-actix-web/commit/f24e11e19f920a641c72ef85a8073bf1997ebd9c))
+* **deps:** update rust crate bon to v3.9.0 ([b46a3d7](https://gitlab.com/lx-industries/rmcp-actix-web/commit/b46a3d76d7ec5c6688b45149ae3c91806c4db676))
+* **deps:** update rust crate insta to v1.46.3 ([f5f8e36](https://gitlab.com/lx-industries/rmcp-actix-web/commit/f5f8e368d34dc1574ccbdeb05d2a2b53d607bbb8))
+* **deps:** update rust crate reqwest to v0.13.2 ([946d8d6](https://gitlab.com/lx-industries/rmcp-actix-web/commit/946d8d642daeca5ef3e7a1f8417a699ace20a9b9))
+* **deps:** update rust crate rmcp to 0.15.0 ([0029fc8](https://gitlab.com/lx-industries/rmcp-actix-web/commit/0029fc8131acb26ba67be6841fd04ae124c6a8f8))
+* **deps:** update rust docker tag to v1.93.1 ([e942a81](https://gitlab.com/lx-industries/rmcp-actix-web/commit/e942a81af5a42bc22d4537fb68d07a88cdbeb246))
+* **deps:** update rust:1.93.0 docker digest to bbde3ca ([bcf2c04](https://gitlab.com/lx-industries/rmcp-actix-web/commit/bcf2c0418ebdd087bb629a6f2d5aeee64cb60024))
+
+## [0.11.0](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.10.0...v0.11.0) (2026-01-25)
+
+
+### Features
+
+* **ci:** add common CI templates for sccache and docker-in-docker ([1f97940](https://gitlab.com/lx-industries/rmcp-actix-web/commit/1f97940661077f888fad8e5427c38829299b48bc))
+* **ci:** add Docker image build and push jobs ([14c6f98](https://gitlab.com/lx-industries/rmcp-actix-web/commit/14c6f98f004653187ba51568c88aaa744f0090a2))
+* **ci:** add Dockerfile for custom Rust image with sccache ([5b0c866](https://gitlab.com/lx-industries/rmcp-actix-web/commit/5b0c866743f09ee27ea1b31cf952d5b779a3c378))
+* **ci:** add sccache to build job ([f1f5b3e](https://gitlab.com/lx-industries/rmcp-actix-web/commit/f1f5b3efe420bba3c692b181690b78bf0a6ac1b7))
+* **ci:** add sccache to clippy job ([3798954](https://gitlab.com/lx-industries/rmcp-actix-web/commit/3798954f091e95c9c1ad60497713ee7f94b964f2))
+* **ci:** add sccache to doc-test job ([ab343d6](https://gitlab.com/lx-industries/rmcp-actix-web/commit/ab343d67067f04590376a9bd9b456055fe59fcb9))
+* **ci:** add sccache to examples job ([b3e9f82](https://gitlab.com/lx-industries/rmcp-actix-web/commit/b3e9f829c22d23fefa5d48ca550bb787cac6f327))
+* **ci:** add sccache to integration-js job ([92e88db](https://gitlab.com/lx-industries/rmcp-actix-web/commit/92e88db195efbc3702786b0152e4d8adeb310c97))
+* **ci:** add sccache to rustdoc job ([c2031f7](https://gitlab.com/lx-industries/rmcp-actix-web/commit/c2031f7aaa82ba6749075eb2a9d5847438e060cc))
+* **ci:** add sccache to test job ([bdaea84](https://gitlab.com/lx-industries/rmcp-actix-web/commit/bdaea84eed92cf0ecf9eeb0b1a18df4dcc1a1421))
+* **ci:** include common and images CI files ([e9584f9](https://gitlab.com/lx-industries/rmcp-actix-web/commit/e9584f981be04f95d543b8861a07b89f6ce67c83))
+* **ci:** track common.gitlab-ci.yml in rust-changes ([0ec9b82](https://gitlab.com/lx-industries/rmcp-actix-web/commit/0ec9b8227a83f89ede992a1558faa31a3d561958))
+* **ci:** use custom Rust image with sccache ([eb761c3](https://gitlab.com/lx-industries/rmcp-actix-web/commit/eb761c32344829230f1066c039f395e62e7d41a1))
+
+
+### Bug Fixes
+
+* **ci:** disable auto-cancel for release pipelines ([ac48b09](https://gitlab.com/lx-industries/rmcp-actix-web/commit/ac48b09c3b2cfeac16dcab8a3916bdf2697319e3))
+* **ci:** only build/push images on push events to main ([0cb4a21](https://gitlab.com/lx-industries/rmcp-actix-web/commit/0cb4a218b83c2a6a15268933ad52791c92668fa5))
+
+
+### Miscellaneous Chores
+
+* **deps:** update rust crate rmcp to 0.14.0 ([95d2ed1](https://gitlab.com/lx-industries/rmcp-actix-web/commit/95d2ed1cb88c74193f5f3f700989270b76f76f09))
+* **deps:** update rust docker tag to v1.93.0 ([6aeefb3](https://gitlab.com/lx-industries/rmcp-actix-web/commit/6aeefb35b0ecf7c5e6b782283b8455b8dd21146f))
+* **deps:** update rust:1.93.0 docker digest to 4c7eb94 ([c13763e](https://gitlab.com/lx-industries/rmcp-actix-web/commit/c13763ee85730cc546388712e9f888ad9fe603da))
+
+## [0.10.0](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.9.5...v0.10.0) (2026-01-21)
+
+
+### Features
+
+* **transport:** add on_request hook for extension propagation ([c4b781a](https://gitlab.com/lx-industries/rmcp-actix-web/commit/c4b781a5b2a7ffe89e7f853d9fa6dab190ff6bc8)), closes [#43](https://gitlab.com/lx-industries/rmcp-actix-web/issues/43)
+
+## [0.9.5](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.9.4...v0.9.5) (2026-01-19)
+
+
+### Miscellaneous Chores
+
+* **deps:** update node.js to 929c026 ([27c5efe](https://gitlab.com/lx-industries/rmcp-actix-web/commit/27c5efe41b146c01d7d40c4d580e3f6c35f20b88))
+* **deps:** update node.js to v24.13.0 ([894b842](https://gitlab.com/lx-industries/rmcp-actix-web/commit/894b842da1e6bcc61fbb8097b90022895ab12314))
+* **deps:** update rust crate chrono to v0.4.43 ([ccc54d3](https://gitlab.com/lx-industries/rmcp-actix-web/commit/ccc54d3dc7e67e1f5adee1a6faf72768f449d138))
+* **deps:** update rust crate insta to v1.46.1 ([f073802](https://gitlab.com/lx-industries/rmcp-actix-web/commit/f0738022c2ac58e487cb8cccfc4a823b9e405d5c))
+* **deps:** update rust crate rmcp to 0.13.0 ([a4e1277](https://gitlab.com/lx-industries/rmcp-actix-web/commit/a4e12779cf8f35e33fbbd0c02881324cfb8a566d))
+* **deps:** update rust:1.92.0 docker digest to bed2d7f ([a99b21a](https://gitlab.com/lx-industries/rmcp-actix-web/commit/a99b21a2713691fb188b7db78106ce844291f2b6))
+
+## [0.9.4](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.9.3...v0.9.4) (2026-01-12)
+
+
+### Miscellaneous Chores
+
+* **deps:** update rust crate bon to v3.8.2 ([8efe627](https://gitlab.com/lx-industries/rmcp-actix-web/commit/8efe627d4e023f9edf8e66ce9f7b2a067cb97d38))
+* **deps:** update rust crate insta to v1.46.0 ([4670e80](https://gitlab.com/lx-industries/rmcp-actix-web/commit/4670e80ac827e20d0ae6f3c85ddc8b6c928a84a4))
+* **deps:** update rust crate serde_json to v1.0.149 ([3c80ba4](https://gitlab.com/lx-industries/rmcp-actix-web/commit/3c80ba4e74f1d4d541b5ca621d73b82945dcfbfe))
+* **deps:** update rust crate tokio-stream to v0.1.18 ([9ba0a06](https://gitlab.com/lx-industries/rmcp-actix-web/commit/9ba0a061f1690c5e1010dd65d77334e718565b3b))
+
+## [0.9.3](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.9.2...v0.9.3) (2026-01-05)
+
+
+### Bug Fixes
+
+* **ci:** skip branch pipeline for release commits ([13d94af](https://gitlab.com/lx-industries/rmcp-actix-web/commit/13d94afde034e06f5a732fbfdbe3c3d61fc273fd))
+
+
+### Miscellaneous Chores
+
+* **deps:** update node.js to b52a8d1 ([1bbe270](https://gitlab.com/lx-industries/rmcp-actix-web/commit/1bbe270ba3eafc53c9cb4f1a0e1c54e4931c22e4))
+* **deps:** update rust crate insta to v1.45.1 ([90ef654](https://gitlab.com/lx-industries/rmcp-actix-web/commit/90ef654d775cb01a727ea4378acaae907b684ac6))
+* **deps:** update rust crate reqwest to 0.13 ([60da586](https://gitlab.com/lx-industries/rmcp-actix-web/commit/60da5867370e057c089c4406499ca059ce0f4dd3))
+* **deps:** update rust crate tokio to v1.49.0 ([d70fa76](https://gitlab.com/lx-industries/rmcp-actix-web/commit/d70fa7659d0a65548b12feb169c1bb30ea33db69))
+* **deps:** update rust:1.92.0 docker digest to 65734d2 ([c3525fb](https://gitlab.com/lx-industries/rmcp-actix-web/commit/c3525fb432b2bba19dbc953fbd9fbec40bbf2ebc))
+* **deps:** update rust:1.92.0 docker digest to 910b9dc ([b3bafcb](https://gitlab.com/lx-industries/rmcp-actix-web/commit/b3bafcbba1c12acc403fec1d1689235b0716aff0))
+
+## [0.9.2](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.9.1...v0.9.2) (2025-12-29)
+
+
+### Miscellaneous Chores
+
+* **deps:** update rust crate reqwest to v0.12.28 ([efe7971](https://gitlab.com/lx-industries/rmcp-actix-web/commit/efe797189fffb250a26cb40378f026168761f669))
+* **deps:** update rust crate serde_json to v1.0.147 ([e15b03f](https://gitlab.com/lx-industries/rmcp-actix-web/commit/e15b03f61bf9df034062216b811b9388549c7661))
+* **deps:** update rust crate serde_json to v1.0.148 ([e6c028f](https://gitlab.com/lx-industries/rmcp-actix-web/commit/e6c028fac9d4fa459ff6cdd64a8ed4521fa74e64))
+
+## [0.9.1](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.9.0...v0.9.1) (2025-12-20)
+
+
+### Miscellaneous Chores
+
+* **deps:** update rust crate insta to v1.45.0 ([30fa712](https://gitlab.com/lx-industries/rmcp-actix-web/commit/30fa712f609bb92329754fda97608bcc97820aee))
+* **deps:** update rust crate reqwest to v0.12.26 ([e759db8](https://gitlab.com/lx-industries/rmcp-actix-web/commit/e759db8fd87ed398fb7a0bcdb7c829cb500dc5a5))
+* **deps:** update rust crate rmcp to 0.12.0 ([109e833](https://gitlab.com/lx-industries/rmcp-actix-web/commit/109e833bd329f25ca800410b4a1256b70a895806))
+* **deps:** update rust crate tracing to v0.1.44 ([b3bc112](https://gitlab.com/lx-industries/rmcp-actix-web/commit/b3bc112a294cd6ce282f30cb05e140aaa519b404))
+* **deps:** update rust:1.92.0 docker digest to 48851a8 ([62b05f5](https://gitlab.com/lx-industries/rmcp-actix-web/commit/62b05f54bc7d5c35f5a2911ada1bbfcb0b218818))
+
+## [0.9.0](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.8.19...v0.9.0) (2025-12-13)
+
+
+### Features
+
+* remove SSE transport support ([38ed5c2](https://gitlab.com/lx-industries/rmcp-actix-web/commit/38ed5c2fbd413e2b42db351f7b7bb6554f5f5e65)), closes [#42](https://gitlab.com/lx-industries/rmcp-actix-web/issues/42)
+
+
+### Miscellaneous Chores
+
+* **deps:** update node.js to 9a2ed90 ([8509ba3](https://gitlab.com/lx-industries/rmcp-actix-web/commit/8509ba310e678f04c2d0544cc95d219b18b515ad))
+* **deps:** update node.js to v24.12.0 ([f5859d3](https://gitlab.com/lx-industries/rmcp-actix-web/commit/f5859d3d21fc868d09548230a181e428ee0c0939))
+* **deps:** update rust crate reqwest to v0.12.25 ([45ff3af](https://gitlab.com/lx-industries/rmcp-actix-web/commit/45ff3afd168a254ff8408882334e902553538695))
+* **deps:** update rust crate rmcp to 0.11.0 ([1413f0f](https://gitlab.com/lx-industries/rmcp-actix-web/commit/1413f0f8dcd15143dae5eaef73cd547a6427f49a))
+* **deps:** update rust docker tag to v1.92.0 ([8b68a8a](https://gitlab.com/lx-industries/rmcp-actix-web/commit/8b68a8adf90b677a099e63e24d22330ac2f90a3e))
+* **deps:** update rust:1.91.1 docker digest to 867f1d1 ([1e6ed3a](https://gitlab.com/lx-industries/rmcp-actix-web/commit/1e6ed3a62ef45b75b3ab114356d4dd73a6724408))
+
+## [0.8.19](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.8.18...v0.8.19) (2025-12-03)
+
+
+### Miscellaneous Chores
+
+* **deps:** remove unused dependencies ([b40b944](https://gitlab.com/lx-industries/rmcp-actix-web/commit/b40b944c6116bf006e5ff627f16ee0e1348f0fc4))
+* **deps:** update rust crate rmcp to 0.10.0 ([57baf85](https://gitlab.com/lx-industries/rmcp-actix-web/commit/57baf8526624434e745e3f85a2999e038bc6d5e3))
+
+## [0.8.18](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.8.17...v0.8.18) (2025-12-01)
+
+
+### Miscellaneous Chores
+
+* **deps:** update rust crate actix-web to v4.12.1 ([af8a3ee](https://gitlab.com/lx-industries/rmcp-actix-web/commit/af8a3ee2ce525af25f763c2b6ea1e67ca15098f5))
+* **deps:** update rust crate insta to v1.44.3 ([e0c67dd](https://gitlab.com/lx-industries/rmcp-actix-web/commit/e0c67dd77a5b4ae8380fe80aaeeed53d6c467c15))
+* **deps:** update tokio-tracing monorepo ([c4b17ce](https://gitlab.com/lx-industries/rmcp-actix-web/commit/c4b17cee838267448fe8eaa0c77b292d0c36f68c))
+
+## [0.8.17](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.8.16...v0.8.17) (2025-11-26)
+
+
+### Miscellaneous Chores
+
+* **deps:** update node.js to v24 ([b4c7ade](https://gitlab.com/lx-industries/rmcp-actix-web/commit/b4c7adee459c860d47c69b2029403779598f8041))
+* **deps:** update rust crate http to v1.4.0 ([0d80ee6](https://gitlab.com/lx-industries/rmcp-actix-web/commit/0d80ee6c633ea7b1da825b7acc6f4bd33bf5777d))
+* **deps:** update rust crate rmcp to v0.9.1 ([a93df09](https://gitlab.com/lx-industries/rmcp-actix-web/commit/a93df09c9468f86f277d71b68c5ef31dc1386db8))
+* **deps:** update rust:1.91.1 docker digest to 4a29b0d ([33e4ca9](https://gitlab.com/lx-industries/rmcp-actix-web/commit/33e4ca9d541e9b777c097f8f14dff376fa8e5955))
+
+## [0.8.16](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.8.15...v0.8.16) (2025-11-24)
+
+
+### Miscellaneous Chores
+
+* **deps:** update rust crate rmcp to 0.9.0 ([5e35d0b](https://gitlab.com/lx-industries/rmcp-actix-web/commit/5e35d0b82a449522785eab75ad4b5c768f2ce183))
+
+## [0.8.15](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.8.14...v0.8.15) (2025-11-22)
+
+
+### Miscellaneous Chores
+
+* **deps:** update node.js to 4ad2c2b ([e358fc1](https://gitlab.com/lx-industries/rmcp-actix-web/commit/e358fc14b49c3e4cc3f8a16dc44fec60730ce16d))
+* **deps:** update rust crate actix-web to v4.12.0 ([bacc223](https://gitlab.com/lx-industries/rmcp-actix-web/commit/bacc223994695f978652b5965c135ead2d982be8))
+* **deps:** update rust:1.91.1 docker digest to ad8c72c ([3da823d](https://gitlab.com/lx-industries/rmcp-actix-web/commit/3da823dfe37df0a6bcf976aa7416b0c367b699e5))
+
+## [0.8.14](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.8.13...v0.8.14) (2025-11-22)
+
+
+### Miscellaneous Chores
+
+* **deps:** update rust docker tag to v1.91.1 ([dfa7212](https://gitlab.com/lx-industries/rmcp-actix-web/commit/dfa721287b3ef00f787d3ca6f56ffeabbb036e2a))
+
+## [0.8.13](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.8.12...v0.8.13) (2025-11-10)
+
+
+### Miscellaneous Chores
+
+* **deps:** update node.js to 5cd9156 ([f4a8c92](https://gitlab.com/lx-industries/rmcp-actix-web/commit/f4a8c920e5e45633d5fdad95c52465d6873aed63))
+* **deps:** update node.js to dcf0610 ([9198690](https://gitlab.com/lx-industries/rmcp-actix-web/commit/919869082619f123286d96643eec506b0afe97dd))
+* **deps:** update rust crate rmcp to v0.8.5 ([1a3981c](https://gitlab.com/lx-industries/rmcp-actix-web/commit/1a3981c84ab1a93c341fd08491180b5fc19ee8f9))
+* **deps:** update rust:1.91.0 docker digest to 087fe68 ([513b507](https://gitlab.com/lx-industries/rmcp-actix-web/commit/513b5071d834bf7154fbedbf91358f18a50ed8b2))
+* **deps:** update rust:1.91.0 docker digest to a0dba1c ([a1642e6](https://gitlab.com/lx-industries/rmcp-actix-web/commit/a1642e67b26845946d798a634d92c892a0e8a1ec))
+
+## [0.8.12](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.8.11...v0.8.12) (2025-11-03)
+
+
+### Miscellaneous Chores
+
+* **deps:** update node.js to v22.21.1 ([baffd6c](https://gitlab.com/lx-industries/rmcp-actix-web/commit/baffd6cde2c30d61f98f2462c0a8cbffcf49bb0f))
+* **deps:** update rust crate tokio-util to v0.7.17 ([7851ca6](https://gitlab.com/lx-industries/rmcp-actix-web/commit/7851ca6eeb13c27b34302d5e8459cb35a9f45a59))
+* **deps:** update rust docker tag to v1.91.0 ([4adc99a](https://gitlab.com/lx-industries/rmcp-actix-web/commit/4adc99a94b603e63503fc9476135dcbdd721e8ac))
+* **deps:** update rust:1.90.0 docker digest to e227f20 ([fed2e7b](https://gitlab.com/lx-industries/rmcp-actix-web/commit/fed2e7b51e65e5cb5055bb168507d0cd8ac584b6))
+
+## [0.8.11](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.8.10...v0.8.11) (2025-10-27)
+
+
+### Miscellaneous Chores
+
+* **deps:** update node.js to 915acd9 ([68d8556](https://gitlab.com/lx-industries/rmcp-actix-web/commit/68d85565ce09ed8778ace301c1638025c11f1c74))
+* **deps:** update node.js to v22.21.0 ([ec36b25](https://gitlab.com/lx-industries/rmcp-actix-web/commit/ec36b25a84bd1fe89f52adcf232315658b2d45fd))
+* **deps:** update rust crate rmcp to v0.8.3 ([b11e944](https://gitlab.com/lx-industries/rmcp-actix-web/commit/b11e9449d48a1071a8b681a98e8b34ebd6976056))
+* **deps:** update rust:1.90.0 docker digest to 52e36cd ([59339c2](https://gitlab.com/lx-industries/rmcp-actix-web/commit/59339c2e6989156c344d971aaae09d39d26fc888))
+
+## [0.8.10](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.8.9...v0.8.10) (2025-10-20)
+
+
+### Miscellaneous Chores
+
+* **deps:** update rust crate reqwest to v0.12.24 ([206024a](https://gitlab.com/lx-industries/rmcp-actix-web/commit/206024ac7464f7c7620c5964b0183a13372008c3))
+* **deps:** update rust crate tokio to v1.48.0 ([e59a347](https://gitlab.com/lx-industries/rmcp-actix-web/commit/e59a347cae849efc62cd575ee9ad26aad2b9109e))
+
+## [0.8.9](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.8.8...v0.8.9) (2025-10-13)
+
+
+### Miscellaneous Chores
+
+* **deps:** update rust crate bon to v3.8.1 ([5815c7e](https://gitlab.com/lx-industries/rmcp-actix-web/commit/5815c7e55d62d6a9f8f35da388f8188211a94010))
+* **deps:** update rust crate rmcp to v0.8.1 ([9f884d5](https://gitlab.com/lx-industries/rmcp-actix-web/commit/9f884d53e6df48a3d616facdaaf81b3a0420ba2d))
+
+## [0.8.8](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.8.7...v0.8.8) (2025-10-06)
+
+
+### Bug Fixes
+
+* align POST handler keep-alive to match with MCP specification ([14c8805](https://gitlab.com/lx-industries/rmcp-actix-web/commit/14c8805bac148c5b80c92a7057819a51bb22aabe))
+* move StreamableHttpService outside HttpServer closure in composition example ([bcac579](https://gitlab.com/lx-industries/rmcp-actix-web/commit/bcac579dd015373596c8ed154c7ab60088f00d08))
+* move StreamableHttpService outside HttpServer closure in counter_streamable_http ([d772748](https://gitlab.com/lx-industries/rmcp-actix-web/commit/d7727488f326403b88c37eecb069886c425b047e))
+* move StreamableHttpService outside HttpServer closure in multi_service example ([68fc582](https://gitlab.com/lx-industries/rmcp-actix-web/commit/68fc582cd60157993c4f95a4ea818ed1c550cc05))
+
+
+### Miscellaneous Chores
+
+* **deps:** update rust crate bon to v3.8.0 ([16e7841](https://gitlab.com/lx-industries/rmcp-actix-web/commit/16e784176a5b2705110d08dd512cf94c1de32b0d))
+* **deps:** update rust:1.90.0 docker digest to 976303c ([8f49647](https://gitlab.com/lx-industries/rmcp-actix-web/commit/8f496477f789baae91de11cee4d851df52afdfc5))
+
+## [0.8.7](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.8.6...v0.8.7) (2025-10-04)
+
+
+### Miscellaneous Chores
+
+* **deps:** update rust crate rmcp to 0.8.0 ([ad75a97](https://gitlab.com/lx-industries/rmcp-actix-web/commit/ad75a97d4e6d2cc134d5b7241505296333378a65))
+
+## [0.8.6](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.8.5...v0.8.6) (2025-10-04)
+
+
+### Bug Fixes
+
+* keep initialization response stream alive with keep-alive pings ([7fde5a3](https://gitlab.com/lx-industries/rmcp-actix-web/commit/7fde5a346955b8458b2358b3a02c14bb1917d806)), closes [#35](https://gitlab.com/lx-industries/rmcp-actix-web/issues/35)
+
+
+### Miscellaneous Chores
+
+* **deps:** update node.js to 2bb201f ([2c9848a](https://gitlab.com/lx-industries/rmcp-actix-web/commit/2c9848a1b59cc268a1504509bae6499293be24bb))
+* **deps:** update rust:1.90.0 docker digest to 04e1ac6 ([5b74d82](https://gitlab.com/lx-industries/rmcp-actix-web/commit/5b74d8292f22556c0c34d6d55dd4686d4119e20f))
+* **deps:** update rust:1.90.0 docker digest to 512d81e ([509a9ec](https://gitlab.com/lx-industries/rmcp-actix-web/commit/509a9ecba93715bfef61362486deb4911e60f359))
+
+## [0.8.5](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.8.4...v0.8.5) (2025-09-29)
+
+
+### Miscellaneous Chores
+
+* **deps:** update node.js to v22.20.0 ([0808052](https://gitlab.com/lx-industries/rmcp-actix-web/commit/0808052b9128cfe505a1ab7ff67d8fae3504a3d7))
+* **deps:** update rust crate serde to v1.0.227 ([8afa275](https://gitlab.com/lx-industries/rmcp-actix-web/commit/8afa275772dae79904330cfbcdde49d41e07596f))
+* **deps:** update rust crate serde to v1.0.228 ([49119e5](https://gitlab.com/lx-industries/rmcp-actix-web/commit/49119e5bcade913cfa82bd58f36024d0636b4eed))
+
+## [0.8.4](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.8.3...v0.8.4) (2025-09-25)
+
+
+### Miscellaneous Chores
+
+* **deps:** update rust crate rmcp to 0.7.0 ([4c0dea0](https://gitlab.com/lx-industries/rmcp-actix-web/commit/4c0dea085578ae93bf55bcc52f53e57a19beae0b))
+
+## [0.8.3](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.8.2...v0.8.3) (2025-09-22)
+
+
+### Miscellaneous Chores
+
+* **deps:** update rust crate anyhow to v1.0.100 ([a3bc89a](https://gitlab.com/lx-industries/rmcp-actix-web/commit/a3bc89a4ed5791ed90c5f68578c29534c37e301e))
+* **deps:** update rust crate serde to v1.0.224 ([15ed901](https://gitlab.com/lx-industries/rmcp-actix-web/commit/15ed9018db57aedf804512e9e21e2df0cf62d075))
+* **deps:** update rust crate serde to v1.0.225 ([aa252e1](https://gitlab.com/lx-industries/rmcp-actix-web/commit/aa252e14a8ea8675fc7ec7bf49e099bca94574a8))
+* **deps:** update rust crate serde to v1.0.226 ([76f074a](https://gitlab.com/lx-industries/rmcp-actix-web/commit/76f074a5a1ddbf78dce8351d24c0c97e714899af))
+* **deps:** update rust docker tag to v1.90.0 ([47218cb](https://gitlab.com/lx-industries/rmcp-actix-web/commit/47218cbfaed4ca8f13253a13632fe3e7645226eb))
+* **deps:** update rust:1.89.0 docker digest to 57407b3 ([db3523f](https://gitlab.com/lx-industries/rmcp-actix-web/commit/db3523f6ab0e5250b771f2c9eaf0c06b63f547f4))
+
+## [0.8.2](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.8.1...v0.8.2) (2025-09-15)
+
+
+### Miscellaneous Chores
+
+* **deps:** update rust crate serde to v1.0.220 ([bb5c9c7](https://gitlab.com/lx-industries/rmcp-actix-web/commit/bb5c9c7e49befb609e5f487f78950fe2d88bbf34))
+* **deps:** update rust crate serde to v1.0.223 ([b618203](https://gitlab.com/lx-industries/rmcp-actix-web/commit/b618203b484e53f0a596bf5fb6a36a55fa91a1bb))
+* **deps:** update rust crate serde_json to v1.0.145 ([95d6762](https://gitlab.com/lx-industries/rmcp-actix-web/commit/95d67623078cca333b96101b4a939448f7cb4bd8))
+
+## [0.8.1](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.8.0...v0.8.1) (2025-09-12)
+
+
+### Miscellaneous Chores
+
+* **deps:** update rmcp from 0.6.3 to 0.6.4 ([143354f](https://gitlab.com/lx-industries/rmcp-actix-web/commit/143354f6c6303147cedd54482746db0ddf4f361c))
+
+## [0.8.0](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.7.0...v0.8.0) (2025-09-11)
+
+
+### Features
+
+* remove the -server suffix from the transport-http-streamable and transport-sse Cargo features ([f65c51c](https://gitlab.com/lx-industries/rmcp-actix-web/commit/f65c51c026d865d4fb66eb82de60fc897bcdbf43))
+
+
+### Miscellaneous Chores
+
+* **deps:** update node.js to afff6d8 ([e3d4ca9](https://gitlab.com/lx-industries/rmcp-actix-web/commit/e3d4ca94cc4da1b0604c644a4d9f295c80ae41be))
+* **deps:** update rust:1.89.0 docker digest to 9e1b362 ([b1c683a](https://gitlab.com/lx-industries/rmcp-actix-web/commit/b1c683a3bb34550c2451745dc26cb529d3803b31))
+
+## [0.7.0](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.6.1...v0.7.0) (2025-09-10)
+
+
+### Features
+
+* add scope_with_path() method for enhanced service mounting flexibility ([ca726be](https://gitlab.com/lx-industries/rmcp-actix-web/commit/ca726be8c0f2261a2b09920816b86f8cc97d66d1)), closes [#29](https://gitlab.com/lx-industries/rmcp-actix-web/issues/29)
+* deprecate SSE transport in favor of StreamableHttp ([3d4fa20](https://gitlab.com/lx-industries/rmcp-actix-web/commit/3d4fa20ad941c50f4af56f024c1e5a77e292b4cc))
+
+
+### Miscellaneous Chores
+
+* **deps:** update node.js to d6ba961 ([cc35803](https://gitlab.com/lx-industries/rmcp-actix-web/commit/cc35803692bb30440e83e47ddbdb56ff7e4788fe))
+* **deps:** update rust crate chrono to v0.4.42 ([2dbb13d](https://gitlab.com/lx-industries/rmcp-actix-web/commit/2dbb13de6d5d03e5b553187d686df3b459a59165))
+* **deps:** update rust:1.89.0 docker digest to 1ca9500 ([9933f6f](https://gitlab.com/lx-industries/rmcp-actix-web/commit/9933f6f4c88292e3e9e3ccf691ca5a577fe5b3a5))
+
+## [0.6.1](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.6.0...v0.6.1) (2025-09-05)
+
+
+### Miscellaneous Chores
+
+* **deps:** update rmcp to version 0.6.3 and fix compilation errors ([73413dc](https://gitlab.com/lx-industries/rmcp-actix-web/commit/73413dc6983312d59b350f49ce87deb70eb423cd)), closes [#28](https://gitlab.com/lx-industries/rmcp-actix-web/issues/28)
+* **deps:** update rust crate insta to v1.43.2 ([ccc6cea](https://gitlab.com/lx-industries/rmcp-actix-web/commit/ccc6cea3928029b38b55db6aa2a2f7e201a2443b))
+
+## [0.6.0](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.5.0...v0.6.0) (2025-09-04)
+
+
+### Features
+
+* add authorization-token-passthrough feature flag ([8ac7ff1](https://gitlab.com/lx-industries/rmcp-actix-web/commit/8ac7ff1aef6ceef2e42bc451971031c985b9a4cc))
+
+
+### Bug Fixes
+
+* forward Authorization header for existing sessions in stateful mode ([a21d49e](https://gitlab.com/lx-industries/rmcp-actix-web/commit/a21d49edb8720c313b0c150804fb0a0162f392dc))
+
+## [0.5.0](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.4.3...v0.5.0) (2025-09-03)
+
+
+### Features
+
+* forward Authorization header for MCP proxy scenarios ([36c6cc7](https://gitlab.com/lx-industries/rmcp-actix-web/commit/36c6cc7e0a9b8ba2805f75d6bc1b8d140c7ed7d8))
+
+
+### Miscellaneous Chores
+
+* **deps:** update rust crate bon to v3.7.2 ([8367e0a](https://gitlab.com/lx-industries/rmcp-actix-web/commit/8367e0a2347d415010a09ec8c60034a5323ce62c))
+
+## [0.4.3](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.4.2...v0.4.3) (2025-09-01)
+
+
+### Miscellaneous Chores
+
+* **deps:** update node.js to v22.19.0 ([226ed11](https://gitlab.com/lx-industries/rmcp-actix-web/commit/226ed11a3d281b1a31c0afa62cbfbd96abbb8a45))
+* **deps:** update rust crate actix-rt to v2.11.0 ([751d11e](https://gitlab.com/lx-industries/rmcp-actix-web/commit/751d11e8607ae9cfcca58fb31999112488cb3921))
+* **deps:** update rust crate tracing-subscriber to v0.3.20 ([dd55343](https://gitlab.com/lx-industries/rmcp-actix-web/commit/dd5534353904a4cd31051656de55d0cd3e7df211))
+
+## [0.4.2](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.4.1...v0.4.2) (2025-08-30)
+
+
+### Miscellaneous Chores
+
+* **deps:** update rust crate rmcp to v0.6.1 ([45bccc2](https://gitlab.com/lx-industries/rmcp-actix-web/commit/45bccc256353da0eddf869013415d70f938e21f1)), closes [#22](https://gitlab.com/lx-industries/rmcp-actix-web/issues/22)
+* **deps:** update rust:1.89.0 docker digest to 3329e2d ([551de5b](https://gitlab.com/lx-industries/rmcp-actix-web/commit/551de5b69b3f5dfa2c34610ab60c58913e12160c))
+
+## [0.4.1](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.4.0...v0.4.1) (2025-08-29)
+
+
+### Bug Fixes
+
+* include scope path in SSE endpoint event URL ([0922c3b](https://gitlab.com/lx-industries/rmcp-actix-web/commit/0922c3ba340693e39266c287a8af29071d24af1b)), closes [#21](https://gitlab.com/lx-industries/rmcp-actix-web/issues/21)
+
+## [0.4.0](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.3.0...v0.4.0) (2025-08-28)
+
+
+### Features
+
+* update StreamableHttpService API and enable Clone pattern ([f85bcfc](https://gitlab.com/lx-industries/rmcp-actix-web/commit/f85bcfcf38b12ad3abfb7357688d0c9bd59da6ea))
+
+## [0.3.0](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.2.9...v0.3.0) (2025-08-28)
+
+
+### Features
+
+* add instance method scope() to StreamableHttpService ([5c5eeed](https://gitlab.com/lx-industries/rmcp-actix-web/commit/5c5eeed9903a75b465f2315e1aa76ea4fa31ae77)), closes [#19](https://gitlab.com/lx-industries/rmcp-actix-web/issues/19)
+* implement unified builder pattern for transport services ([fbd0121](https://gitlab.com/lx-industries/rmcp-actix-web/commit/fbd0121af8aa8c867d754ea6ace959b93831a61e))
+
+
+### Miscellaneous Chores
+
+* **deps:** update rust:1.89.0 docker digest to 26318ae ([b4def23](https://gitlab.com/lx-industries/rmcp-actix-web/commit/b4def23125a3c7db308c1d7258970ce59a072964))
+
+## [0.2.9](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.2.8...v0.2.9) (2025-08-21)
+
+
+### Bug Fixes
+
+* calculator example/test return type ([1bea804](https://gitlab.com/lx-industries/rmcp-actix-web/commit/1bea8043edad2dc4cae0d173a6be58e014581dfa))
+* wrong HTTP header name for the MCP session id in the examples ([e01257a](https://gitlab.com/lx-industries/rmcp-actix-web/commit/e01257a111a6012c2f42cef359364b0281b462f6))
+
+## [0.2.8](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.2.7...v0.2.8) (2025-08-21)
+
+
+### Bug Fixes
+
+* **ci:** run all tests including integration tests ([cd07a8b](https://gitlab.com/lx-industries/rmcp-actix-web/commit/cd07a8b0262ca01b6953471e057f00e9465410a8)), closes [#16](https://gitlab.com/lx-industries/rmcp-actix-web/issues/16)
+* session handling inconsistencies in the examples ([9e737dc](https://gitlab.com/lx-industries/rmcp-actix-web/commit/9e737dc2c6d4c01ca939edfca2c6696fb561d692)), closes [#15](https://gitlab.com/lx-industries/rmcp-actix-web/issues/15)
+
+
+### Miscellaneous Chores
+
+* **deps:** update rust crate rmcp to 0.6.0 ([31b7262](https://gitlab.com/lx-industries/rmcp-actix-web/commit/31b7262bec4ab9327b2a69fc174c0da7ff461509))
+* **deps:** update rust crate serde_json to v1.0.143 ([163a043](https://gitlab.com/lx-industries/rmcp-actix-web/commit/163a04381132c48b992d903a1e574b341e8f6bc9))
+* **deps:** update rust:1.89.0 docker digest to 6e6d04b ([892b8b5](https://gitlab.com/lx-industries/rmcp-actix-web/commit/892b8b508112767f39de9f3319c5fd94fdcdef2b))
+
+## [0.2.7](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.2.6...v0.2.7) (2025-08-18)
+
+
+### Miscellaneous Chores
+
+* **deps:** update node.js to 3266bc9 ([79bd416](https://gitlab.com/lx-industries/rmcp-actix-web/commit/79bd416b141258425a1b869e8ff1ea8d7937a15b))
+* **deps:** update node.js to 5cc5271 ([b16e53f](https://gitlab.com/lx-industries/rmcp-actix-web/commit/b16e53f4781122ce3033c77ffa6a7c475e2a53f5))
+* **deps:** update rust crate anyhow to v1.0.99 ([61979a0](https://gitlab.com/lx-industries/rmcp-actix-web/commit/61979a0343fdd3a35a9093eed8d1241740f3b638))
+* **deps:** update rust crate reqwest to v0.12.23 ([dbb4e82](https://gitlab.com/lx-industries/rmcp-actix-web/commit/dbb4e829e3c994dc36ea74861829e0829c1f5343))
+* **deps:** update rust:1.89.0 docker digest to 5fa1490 ([7d3ec02](https://gitlab.com/lx-industries/rmcp-actix-web/commit/7d3ec022fccd77eb6f7e24459a0dbe86769b3375))
+* **deps:** update rust:1.89.0 docker digest to ded0544 ([b2207d3](https://gitlab.com/lx-industries/rmcp-actix-web/commit/b2207d34980ac4149b8888ceba73fbc6c0318e37))
+* **deps:** update rust:1.89.0 docker digest to e090f7b ([4e9a3c9](https://gitlab.com/lx-industries/rmcp-actix-web/commit/4e9a3c95a44960d153d5e1b2e6e22dd32996afed))
+
+## [0.2.6](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.2.5...v0.2.6) (2025-08-11)
+
+
+### Miscellaneous Chores
+
+* **deps:** update node.js to v22.18.0 ([2aee55e](https://gitlab.com/lx-industries/rmcp-actix-web/commit/2aee55e4c8229c2a2cc013476b78a23aba4dfcf4))
+* **deps:** update rust crate rmcp to 0.4.0 ([e084de8](https://gitlab.com/lx-industries/rmcp-actix-web/commit/e084de8fee8b9ceed4adcc8537ba28f69911b3a3))
+* **deps:** update rust crate rmcp to 0.5.0 ([7f48c7f](https://gitlab.com/lx-industries/rmcp-actix-web/commit/7f48c7fc47669ba68911861a2c3bd56475ce0205))
+* **deps:** update rust crate rmcp to v0.4.1 ([4ff8ad1](https://gitlab.com/lx-industries/rmcp-actix-web/commit/4ff8ad1de2fadf378d1379c53da5626094963016))
+* **deps:** update rust docker tag to v1.89.0 ([83434cd](https://gitlab.com/lx-industries/rmcp-actix-web/commit/83434cd12cac89d2c35efc7faca4a9e6d22a350b))
+
+## [0.2.5](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.2.4...v0.2.5) (2025-08-04)
+
+
+### Miscellaneous Chores
+
+* **deps:** update rust crate rmcp to v0.3.1 ([7838b24](https://gitlab.com/lx-industries/rmcp-actix-web/commit/7838b24e0011515f093c5f3d9a8cf9bc0f804f09))
+* **deps:** update rust crate rmcp to v0.3.2 ([175e47f](https://gitlab.com/lx-industries/rmcp-actix-web/commit/175e47f683afb959c2cc647d7849ad78297f72ca))
+* **deps:** update rust crate serde_json to v1.0.142 ([3ffe715](https://gitlab.com/lx-industries/rmcp-actix-web/commit/3ffe7155ac2ea7c5ddd3e196a917442ecb672a88))
+* **deps:** update rust crate tokio to v1.47.1 ([6e30b25](https://gitlab.com/lx-industries/rmcp-actix-web/commit/6e30b257050f404375990b8cef859a8c003be18d))
+* **deps:** update rust crate tokio-util to v0.7.16 ([7adddfa](https://gitlab.com/lx-industries/rmcp-actix-web/commit/7adddfad9e86556289c4021c84bd6d24923d824c))
+
+## [0.2.4](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.2.3...v0.2.4) (2025-07-28)
+
+
+### Bug Fixes
+
+* add .gitlab-ci.yml to rust-changes pattern ([c890b6f](https://gitlab.com/lx-industries/rmcp-actix-web/commit/c890b6fea33e2496352b9c66782898a0bad420ef))
+
+
+### Miscellaneous Chores
+
+* **deps:** update node.js to 079b6a6 ([e9c8dc6](https://gitlab.com/lx-industries/rmcp-actix-web/commit/e9c8dc6ec0ec5b1de18621616c7d7a93a3004a8d))
+* **deps:** update node.js to 37ff334 ([6ba8d7b](https://gitlab.com/lx-industries/rmcp-actix-web/commit/6ba8d7bb70ea15b2feb4c3a5656328c62d847ca5))
+* **deps:** update node.js to e515259 ([606eb33](https://gitlab.com/lx-industries/rmcp-actix-web/commit/606eb333b73ba3f73a3b4f17ab0b8fa612d318d1))
+* **deps:** update rust crate tokio to v1.47.0 ([d9dea1c](https://gitlab.com/lx-industries/rmcp-actix-web/commit/d9dea1cf77e76df4814d6b30000934ca06a4a159))
+* **deps:** update rust:1.88.0 docker digest to a5c5c4b ([edb3a60](https://gitlab.com/lx-industries/rmcp-actix-web/commit/edb3a60d89583db05bd8e61898c619d8b6bbc393))
+* **deps:** update rust:1.88.0 docker digest to af306cf ([38d0324](https://gitlab.com/lx-industries/rmcp-actix-web/commit/38d032423785dfb5bbba215ba697b33bc60eac32))
+* **deps:** update rust:1.88.0 docker digest to d8fb475 ([14d22f2](https://gitlab.com/lx-industries/rmcp-actix-web/commit/14d22f225924982ec3e17e7dab912c372eb8a171))
+
+## [0.2.3](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.2.2...v0.2.3) (2025-07-21)
+
+
+### Miscellaneous Chores
+
+* **deps:** update rust crate serde_json to v1.0.141 ([0484466](https://gitlab.com/lx-industries/rmcp-actix-web/commit/04844662ec8cdc567637ca1018c79c9a70be0107))
+
+## [0.2.2](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.2.1...v0.2.2) (2025-07-17)
+
+
+### Miscellaneous Chores
+
+* **deps:** update node.js to v22.17.1 ([805838e](https://gitlab.com/lx-industries/rmcp-actix-web/commit/805838eb6e8eaa61df5797e286509e3e84510800))
+* **deps:** update rust crate rmcp to v0.3.0 ([6b340ee](https://gitlab.com/lx-industries/rmcp-actix-web/commit/6b340ee89466aa0f82510d702ad71db90c64346b))
+
+## [0.2.1](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.2.0...v0.2.1) (2025-07-11)
+
+
+### Miscellaneous Chores
+
+* **deps:** update node.js to 2c3f34d ([48bd4c6](https://gitlab.com/lx-industries/rmcp-actix-web/commit/48bd4c6a318e5564444491e8eff1614122d76476))
+* **deps:** update node.js to v22 ([4f765a2](https://gitlab.com/lx-industries/rmcp-actix-web/commit/4f765a2fd8ea8e1dc167041a23b65453cd9f54d2))
+* **deps:** update rust crate tokio to v1.46.1 ([1124982](https://gitlab.com/lx-industries/rmcp-actix-web/commit/11249822ee69d9d69849695aa10293265bc3e6ba))
+* **deps:** update rust:1.88.0 docker digest to 5771a3c ([00ec1b4](https://gitlab.com/lx-industries/rmcp-actix-web/commit/00ec1b4bf260bbd589e5be54979a0bd705006147))
+
+## [0.2.0](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.1.0...v0.2.0) (2025-07-07)
+
+
+### Features
+
+* add Cargo features for selective transport compilation ([7bebcdb](https://gitlab.com/lx-industries/rmcp-actix-web/commit/7bebcdb5b037037d17824df85966ce26c9473538)), closes [#10](https://gitlab.com/lx-industries/rmcp-actix-web/issues/10)
+* add framework-level composition APIs aligned with RMCP patterns ([c82e514](https://gitlab.com/lx-industries/rmcp-actix-web/commit/c82e51425c2d7518a4fcff81a85231848785c703)), closes [#11](https://gitlab.com/lx-industries/rmcp-actix-web/issues/11)
+
+## [0.1.0](https://gitlab.com/lx-industries/rmcp-actix-web/compare/v0.0.0...v0.1.0) (2025-07-05)
+
+
+### Features
+
+* add actix-web MCP transport with GitLab CI pipeline ([c1af689](https://gitlab.com/lx-industries/rmcp-actix-web/commit/c1af689ba42aca9d1bd57a2f3ce5c57351480b0f))
+* extract actix-web transport from rust-sdk ([b32bb32](https://gitlab.com/lx-industries/rmcp-actix-web/commit/b32bb32cc55b37ee8658a6614c70b01d2b9a8e7c))
+
+
+### Bug Fixes
+
+* keywords must have less than 20 characters error when running cargo publish ([01fc85b](https://gitlab.com/lx-industries/rmcp-actix-web/commit/01fc85b953c606a662d5b5560b2e1ee6097b2de2))

--- a/api/vendor/rmcp-actix-web/Cargo.toml
+++ b/api/vendor/rmcp-actix-web/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+edition = "2024"
+name = "rmcp-actix-web"
+version = "0.12.3"
+description = "actix-web transport implementations for RMCP (Rust Model Context Protocol)"
+homepage = "https://gitlab.com/lx-industries/rmcp-actix-web"
+readme = "README.md"
+keywords = [
+    "mcp",
+    "actix",
+    "actix-web",
+    "protocol",
+    "llm",
+]
+categories = [
+    "network-programming",
+    "web-programming",
+]
+license = "MIT"
+repository = "https://gitlab.com/lx-industries/rmcp-actix-web"
+
+[features]
+authorization-token-passthrough = []
+default = ["transport-streamable-http"]
+transport-streamable-http = ["rmcp/transport-streamable-http-server"]
+
+[lib]
+name = "rmcp_actix_web"
+path = "src/lib.rs"
+
+[dependencies]
+actix-web = { version = "4", default-features = false }
+async-stream = "0.3"
+async-trait = "0.1"
+bon = "3.7.1"
+futures = "0.3"
+rmcp = { version = "1.6", features = ["server", "transport-streamable-http-server-session"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0", features = ["preserve_order"] }
+tokio = { version = "1", features = ["sync", "macros", "rt", "time", "process"] }
+tokio-stream = "0.1"
+tracing = "0.1"

--- a/api/vendor/rmcp-actix-web/LICENSE
+++ b/api/vendor/rmcp-actix-web/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Model Context Protocol
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/api/vendor/rmcp-actix-web/README.md
+++ b/api/vendor/rmcp-actix-web/README.md
@@ -1,0 +1,218 @@
+# rmcp-actix-web
+
+actix-web transport implementations for RMCP (Rust Model Context Protocol)
+
+This crate provides actix-web-based transport implementations for the Model Context Protocol, offering a complete alternative to the default Axum-based transports in the main RMCP crate.
+
+## Overview
+
+`rmcp-actix-web` provides:
+- **Streamable HTTP transport**: Bidirectional communication with session management
+- **Framework-level composition**: Mount MCP services at custom paths using actix-web Scope
+- **Full MCP compatibility**: Implements the complete MCP protocol specification
+- **RMCP ecosystem alignment**: APIs that follow RMCP patterns for maximum consistency
+
+## ⚠️ Security Notice
+
+This transport forwards Authorization headers to MCP services. If your MCP service passes these tokens to upstream APIs (proxy pattern), be aware this violates MCP specifications. See [SECURITY.md](SECURITY.md) for details.
+
+## Contributing
+
+We welcome contributions to `rmcp-actix-web`! Please follow these guidelines:
+
+### How to Contribute
+
+1. **Fork the repository** on GitLab
+2. **Create a feature branch** from `main`: `git checkout -b feature/my-new-feature`
+3. **Make your changes** and ensure they follow the project's coding standards
+4. **Add tests** for your changes if applicable and run examples to verify functionality
+5. **Run the test suite** to ensure nothing is broken: `cargo test`
+6. **Commit your changes** with clear, descriptive commit messages
+7. **Push to your fork** and **create a merge request**
+
+### Development Setup
+
+```bash
+# Clone your fork
+git clone https://gitlab.com/your-username/rmcp-actix-web.git
+cd rmcp-actix-web
+
+# Build the project
+cargo build --workspace
+
+# Run tests
+cargo test
+
+# Run examples
+cargo run --example counter_streamable_http
+```
+
+### Code Standards
+
+- Follow Rust conventions and use `cargo fmt` to format code
+- Run `cargo clippy --all-targets` to catch common mistakes
+- Add documentation for public APIs
+- Include tests for new functionality
+
+### Reporting Issues
+
+Found a bug or have a feature request? Please report it on our [GitLab issue tracker](https://gitlab.com/lx-industries/rmcp-actix-web/-/issues).
+
+## Installation
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+rmcp-actix-web = "0.2"
+rmcp = "0.3"
+actix-web = "4"
+```
+
+### Feature Flags
+
+Control which transports are compiled:
+
+```toml
+# Default: StreamableHttp transport enabled
+rmcp-actix-web = "0.2"
+
+# Only StreamableHttp transport (explicit)
+rmcp-actix-web = { version = "0.2", default-features = false, features = ["transport-streamable-http-server"] }
+```
+
+## Compatibility Matrix
+
+| rmcp-actix-web | rmcp |
+|----------------|------|
+| 0.6.1          | 0.6.3|
+| 0.4.2          | 0.6.1|
+| 0.2.2          | 0.3.0|
+| 0.2.x          | 0.2.x|
+| 0.1.x          | 0.2.x|
+
+## Quick Start
+
+### Framework-Level Composition
+
+Mount MCP services at custom paths within existing actix-web applications:
+
+```rust
+use rmcp_actix_web::StreamableHttpService;
+use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+use actix_web::{App, HttpServer, web};
+use std::sync::Arc;
+
+#[actix_web::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // StreamableHttp service with builder pattern (shared across workers)
+    let http_service = StreamableHttpService::builder()
+        .service_factory(Arc::new(|| Ok(MyMcpService::new())))
+        .session_manager(Arc::new(LocalSessionManager::default()))
+        .stateful_mode(true)
+        .build();
+
+    HttpServer::new(move || {
+        App::new()
+            // Your existing routes
+            .route("/health", web::get().to(|| async { "OK" }))
+            // Mount MCP service at custom path
+            .service(web::scope("/api/v1/mcp").service(http_service.clone().scope()))
+    })
+    .bind("127.0.0.1:8080")?
+    .run()
+    .await?;
+
+    Ok(())
+}
+```
+
+## Examples
+
+See the `examples/` directory for complete working examples:
+
+### Basic Examples
+- `counter_streamable_http.rs` - Streamable HTTP server example
+
+### Composition Examples
+- `composition_streamable_http_example.rs` - StreamableHttp with custom mounting
+
+### Proxy Examples
+- `authorization_proxy_example.rs` - MCP service acting as a proxy using Authorization headers
+
+### Running Examples
+
+```bash
+# Basic StreamableHttp server
+cargo run --example counter_streamable_http
+
+# Framework composition with StreamableHttp
+cargo run --example composition_streamable_http_example
+
+# Authorization proxy example
+cargo run --example authorization_proxy_example
+```
+
+Each example includes detailed documentation and curl commands for testing.
+
+## Key Features
+
+### Framework-Level Composition
+- **StreamableHttp**: `StreamableHttpService::builder().build()` with `.scope()` for composition
+- **Custom Paths**: Mount services at any path using actix-web's Scope system
+- **Builder API**: Consistent builder pattern for service configuration
+
+### Protocol Support
+- **Full MCP Compatibility**: Implements complete MCP protocol specification
+- **Bidirectional Communication**: Both request/response and streaming patterns
+- **Session Management**: Stateful and stateless modes for StreamableHttp
+- **Keep-Alive**: Configurable keep-alive intervals for connection health
+
+### Integration
+- **Drop-in Replacement**: Same service implementations work with Axum or actix-web
+- **Middleware Support**: Full integration with actix-web middleware stack
+- **Custom Paths**: Mount services at any path using actix-web's Scope system
+- **Built on actix-web**: Leverages the mature actix-web framework
+
+### Middleware Extension Propagation
+
+Use the `on_request` hook to propagate typed data from actix-web middleware to MCP request handlers. This is useful for passing JWT claims, user context, or other authentication data:
+
+```rust
+use rmcp_actix_web::StreamableHttpService;
+use actix_web::HttpMessage;
+use std::sync::Arc;
+
+#[derive(Clone)]
+struct JwtClaims { user_id: String }
+
+let http_service = StreamableHttpService::builder()
+    .service_factory(Arc::new(|| Ok(MyMcpService::new())))
+    .session_manager(Arc::new(LocalSessionManager::default()))
+    .on_request_fn(|http_req, ext| {
+        // Access data populated by actix-web middleware
+        if let Some(claims) = http_req.extensions().get::<JwtClaims>() {
+            ext.insert(claims.clone());
+        }
+    })
+    .build();
+```
+
+The propagated extensions are accessible in your MCP service handlers via `RequestContext::extensions`.
+
+### Proxy Support
+- **Authorization Forwarding**: Bearer tokens from Authorization headers can be forwarded to MCP services (requires `authorization-token-passthrough` feature)
+- **MCP Proxy Pattern**: Enable MCP services to act as proxies to backend APIs
+- **Selective Header Forwarding**: Only forwards Authorization header when feature is enabled
+- **Type-Safe Access**: Access forwarded headers via `RequestContext` extensions
+- **Security Notice**: Token passthrough violates MCP specifications - see [SECURITY.md](SECURITY.md) for important details
+
+## License
+
+MIT License - see LICENSE file for details.
+
+## References
+
+- [Model Context Protocol Specification](https://modelcontextprotocol.io/)
+- [RMCP Rust SDK](https://github.com/modelcontextprotocol/rust-sdk)
+- [Original PR #294](https://github.com/modelcontextprotocol/rust-sdk/pull/294)

--- a/api/vendor/rmcp-actix-web/SECURITY.md
+++ b/api/vendor/rmcp-actix-web/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Considerations
+
+## Authorization Header Forwarding
+
+This transport layer forwards Authorization headers from HTTP requests to MCP services. This enables two distinct architectural patterns:
+
+### Pattern 1: MCP Service Authentication (MCP-Compliant)
+- The Authorization header authenticates the client to the MCP service
+- The MCP service validates tokens intended for itself
+- The MCP service uses separate credentials for any upstream API calls
+- **This follows MCP specification requirements**
+
+### Pattern 2: Token Passthrough Proxy (Non-Compliant)
+- The Authorization header is forwarded through the MCP service to backend APIs
+- The MCP service acts as a transparent proxy for authentication
+- Backend APIs receive and validate the original client tokens
+- **This violates MCP specification: "MCP servers MUST NOT pass through the token it received from the MCP client"**
+
+## Security Implications
+
+When using Pattern 2 (Token Passthrough):
+- **Confused Deputy Risk**: Tokens meant for one service are used at another
+- **Audience Validation**: Backend APIs MUST validate token audience claims
+- **Token Scoping**: Clients MUST obtain tokens scoped for the backend API, not the MCP server
+
+## Recommendations
+
+1. **For MCP Services**: Validate tokens according to OAuth 2.1 Section 5.2
+2. **For Proxy Implementations**: Document clearly that token passthrough violates MCP spec
+3. **For Production Use**: Consider implementing proper OAuth delegation instead of passthrough
+
+See [rmcp-openapi#67](https://gitlab.com/lx-industries/rmcp-openapi/-/issues/67) for detailed discussion.

--- a/api/vendor/rmcp-actix-web/justfile
+++ b/api/vendor/rmcp-actix-web/justfile
@@ -1,0 +1,42 @@
+# Launch an interactive devcontainer shell (e.g. `just dev-shell`, `just dev-shell claude`)
+# Add --firewall for network-firewalled autonomous mode.
+[positional-arguments]
+dev-shell *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    docker build -t rmcp-actix-web-devcontainer .devcontainer/
+    tty_flag=$( [[ -t 0 ]] && echo "-it" || echo "-i" )
+    run_args=(
+        --rm $tty_flag --init
+        -v "$(pwd):$(pwd)" -w "$(pwd)"
+        -v "$SSH_AUTH_SOCK:/tmp/ssh-agent.sock"
+        -e SSH_AUTH_SOCK=/tmp/ssh-agent.sock
+        -e COLORTERM="${COLORTERM:-}"
+        -e DEVCONTAINER_WORKSPACE="$(pwd)"
+    )
+    # Firewalled mode: iptables egress filter + run as root then drop privileges via gosu
+    # Normal mode: run directly as host UID (no firewall, no caps)
+    if [[ "${1:-}" = "--firewall" ]]; then
+        shift
+        run_args+=(
+            --cap-add=NET_ADMIN --cap-add=NET_RAW
+            -e DEVCONTAINER_FIREWALL=1
+            -e DEVCONTAINER_UID="$(id -u)"
+            -e DEVCONTAINER_GID="$(id -g)"
+        )
+    else
+        run_args+=(--user "$(id -u):$(id -g)")
+    fi
+    # Conditional host config mounts
+    [[ -f "$HOME/.gitconfig" ]] && run_args+=(-v "$HOME/.gitconfig:/tmp/home/.gitconfig:ro")
+    [[ -d "$HOME/.config/glab-cli" ]] && run_args+=(-v "$HOME/.config/glab-cli:/tmp/glab-config")
+    [[ -d "$HOME/.claude" ]] && run_args+=(
+        -v "$HOME/.claude:/tmp/home/.claude"
+        -v "$HOME/.claude:$HOME/.claude"
+    )
+    [[ -f "$HOME/.claude.json" ]] && run_args+=(-v "$HOME/.claude.json:/tmp/home/.claude.json")
+    if [[ $# -eq 0 ]]; then
+        exec docker run "${run_args[@]}" rmcp-actix-web-devcontainer bash
+    else
+        exec docker run "${run_args[@]}" rmcp-actix-web-devcontainer "$@"
+    fi

--- a/api/vendor/rmcp-actix-web/renovate.json
+++ b/api/vendor/rmcp-actix-web/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["local>lx-industries/renovate-config"]
+}

--- a/api/vendor/rmcp-actix-web/src/lib.rs
+++ b/api/vendor/rmcp-actix-web/src/lib.rs
@@ -1,0 +1,122 @@
+//! # rmcp-actix-web
+//!
+#![warn(missing_docs)]
+//! actix-web transport implementations for RMCP (Rust Model Context Protocol).
+//!
+//! This crate provides HTTP-based transport layers for the [Model Context Protocol (MCP)][mcp],
+//! offering a complete alternative to the default Axum-based transports in the main [RMCP crate][rmcp].
+//! If you're already using actix-web in your application or prefer its API, this crate allows
+//! you to integrate MCP services seamlessly without introducing additional web frameworks.
+//!
+//! [mcp]: https://modelcontextprotocol.io/
+//! [rmcp]: https://crates.io/crates/rmcp
+//!
+//! ## Features
+//!
+//! - **[Streamable HTTP Transport][StreamableHttpService]**: Bidirectional communication with session management
+//! - **Full MCP Compatibility**: Implements the complete MCP specification
+//! - **Drop-in Replacement**: Same service implementations work with either Axum or actix-web transports
+//! - **Production Ready**: Built on battle-tested actix-web framework
+//!
+//! ## Quick Start
+//!
+//! ### Streamable HTTP Server Example
+//!
+//! ```rust,no_run
+//! use rmcp_actix_web::transport::{StreamableHttpService, AuthorizationHeader};
+//! use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+//! use rmcp::{ServerHandler, model::ServerInfo};
+//! use actix_web::{App, HttpServer};
+//! use std::{sync::Arc, time::Duration};
+//!
+//! # #[derive(Clone)]
+//! # struct MyMcpService;
+//! # impl ServerHandler for MyMcpService {
+//! #     fn get_info(&self) -> ServerInfo { ServerInfo::default() }
+//! # }
+//! # impl MyMcpService {
+//! #     fn new() -> Self { Self }
+//! # }
+//! #[actix_web::main]
+//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     // Create service OUTSIDE HttpServer::new() to share across workers
+//!     let http_service = StreamableHttpService::builder()
+//!         .service_factory(Arc::new(|| Ok(MyMcpService::new())))
+//!         .session_manager(Arc::new(LocalSessionManager::default()))
+//!         .stateful_mode(true)
+//!         .sse_keep_alive(Duration::from_secs(30))
+//!         .build();
+//!
+//!     HttpServer::new(move || {
+//!         App::new()
+//!             // Clone service for each worker (shares the same LocalSessionManager)
+//!             .service(http_service.clone().scope())
+//!     })
+//!     .bind("127.0.0.1:8080")?
+//!     .run()
+//!     .await?;
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
+//! ## Examples
+//!
+//! See the `examples/` directory for complete working examples:
+//! - `counter_streamable_http.rs` - Streamable HTTP server example
+//! - `composition_streamable_http_example.rs` - StreamableHttp with custom mounting
+//! - `authorization_proxy_example.rs` - Authorization header forwarding example
+//!
+//! ## Framework-Level Composition
+//!
+//! The transport supports framework-level composition aligned with RMCP patterns,
+//! allowing you to mount MCP services at custom paths within existing actix-web applications.
+//!
+//! ### Service Composition
+//!
+//! ```rust,no_run
+//! use rmcp_actix_web::transport::{StreamableHttpService, AuthorizationHeader};
+//! use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+//! use actix_web::{App, web};
+//! use std::{sync::Arc, time::Duration};
+//!
+//! # use rmcp::{ServerHandler, model::ServerInfo};
+//! # #[derive(Clone)]
+//! # struct MyService;
+//! # impl ServerHandler for MyService {
+//! #     fn get_info(&self) -> ServerInfo { ServerInfo::default() }
+//! # }
+//! # impl MyService { fn new() -> Self { Self } }
+//! # use actix_web::HttpServer;
+//! # #[actix_web::main]
+//! # async fn main() -> std::io::Result<()> {
+//! // Create service OUTSIDE HttpServer::new() to share across workers
+//! let http_service = StreamableHttpService::builder()
+//!     .service_factory(Arc::new(|| Ok(MyService::new())))
+//!     .session_manager(Arc::new(LocalSessionManager::default()))
+//!     .stateful_mode(true)
+//!     .sse_keep_alive(Duration::from_secs(30))
+//!     .build();
+//!
+//! HttpServer::new(move || {
+//!     // Mount at custom path using scope() (cloned for each worker)
+//!     App::new()
+//!         .service(web::scope("/api/v1/calculator").service(http_service.clone().scope()))
+//! }).bind("127.0.0.1:8080")?.run().await
+//! # }
+//! ```
+//!
+//
+//! See the `examples/` directory for complete working examples of composition patterns.
+//!
+//! ## Performance Considerations
+//!
+//! - Streamable HTTP maintains persistent sessions which may use more memory
+//! - Uses efficient async I/O through actix-web's actor system
+//! - Framework-level composition adds minimal overhead
+//!
+//! ## Feature Flags
+//!
+//! - `transport-streamable-http` (default): Enables StreamableHttp transport
+
+pub mod transport;

--- a/api/vendor/rmcp-actix-web/src/transport/mod.rs
+++ b/api/vendor/rmcp-actix-web/src/transport/mod.rs
@@ -1,0 +1,134 @@
+//! Transport implementations for the Model Context Protocol using actix-web.
+//!
+//! This module provides HTTP-based transport layers that enable MCP services
+//! to communicate with clients over standard web protocols.
+//!
+//! ## Streamable HTTP
+//!
+//! The [`streamable_http_server`] module provides a bidirectional transport
+//! with session management. This is ideal for:
+//! - Full request/response communication patterns
+//! - Maintaining client state across requests
+//! - Complex interaction patterns
+//! - Higher performance for bidirectional communication
+//!
+//! See [`StreamableHttpService`][crate::StreamableHttpService] for the main implementation.
+//!
+//! ## Framework-Level Composition
+//!
+//! The transport supports framework-level composition for mounting at custom paths
+//! using a builder pattern:
+//!
+//! ```rust,no_run
+//! use actix_web::{App, HttpServer, web};
+//! use rmcp_actix_web::transport::StreamableHttpService;
+//! use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+//! use std::{sync::Arc, time::Duration};
+//!
+//! # use rmcp::{ServerHandler, model::ServerInfo};
+//! # #[derive(Clone)]
+//! # struct MyService;
+//! # impl ServerHandler for MyService {
+//! #     fn get_info(&self) -> ServerInfo { ServerInfo::default() }
+//! # }
+//! # impl MyService { fn new() -> Self { Self } }
+//! #[actix_web::main]
+//! async fn main() -> std::io::Result<()> {
+//!     // Create service OUTSIDE HttpServer::new() to share across workers
+//!     let http_service = StreamableHttpService::builder()
+//!         .service_factory(Arc::new(|| Ok(MyService::new())))
+//!         .session_manager(Arc::new(LocalSessionManager::default()))
+//!         .stateful_mode(true)
+//!         .sse_keep_alive(Duration::from_secs(30))
+//!         .build();
+//!
+//!     HttpServer::new(move || {
+//!         App::new()
+//!             // Mount StreamableHttp service at /api/v1/mcp/ (cloned for each worker)
+//!             .service(web::scope("/api/v1/mcp").service(http_service.clone().scope()))
+//!     })
+//!     .bind("127.0.0.1:8080")?
+//!     .run()
+//!     .await
+//! }
+//! ```
+//!
+//! ## Propagating Extensions from Middleware
+//!
+//! Use the `on_request` hook to propagate typed data from actix-web middleware
+//! to MCP request handlers. This is useful for passing authentication claims,
+//! request metadata, or other context from HTTP middleware to your MCP service:
+//!
+//! ```rust,ignore
+//! use rmcp_actix_web::transport::StreamableHttpService;
+//! use actix_web::HttpMessage;
+//! use std::sync::Arc;
+//!
+//! #[derive(Clone)]
+//! struct JwtClaims { user_id: String }
+//!
+//! let service = StreamableHttpService::builder()
+//!     .service_factory(Arc::new(|| Ok(MyService::new())))
+//!     .session_manager(Arc::new(LocalSessionManager::default()))
+//!     .on_request_fn(|http_req, ext| {
+//!         // Access data populated by actix-web middleware
+//!         if let Some(claims) = http_req.extensions().get::<JwtClaims>() {
+//!             ext.insert(claims.clone());
+//!         }
+//!     })
+//!     .build();
+//! ```
+//!
+//! The propagated extensions are then accessible in your MCP service handlers
+//! via `RequestContext::extensions`.
+//!
+//! ## Protocol Compatibility
+//!
+//! The transport implements the [MCP protocol specification][mcp] and is compatible
+//! with all MCP clients that support HTTP transports. The wire protocol is
+//! identical to the Axum-based transports in the main [RMCP crate][rmcp].
+//!
+//! [mcp]: https://modelcontextprotocol.io/
+//! [rmcp]: https://docs.rs/rmcp/
+
+/// Streamable HTTP transport implementation.
+///
+/// Provides bidirectional communication with session management.
+#[cfg(feature = "transport-streamable-http")]
+pub mod streamable_http_server;
+#[cfg(feature = "transport-streamable-http")]
+pub use streamable_http_server::{
+    OnRequestHook, StreamableHttpServerConfig, StreamableHttpService, StreamableHttpServiceBuilder,
+};
+
+/// Re-export of rmcp's Extensions type for use with on_request hook.
+pub use rmcp::model::Extensions;
+
+/// Authorization header value for MCP proxy scenarios.
+///
+/// This type is used to pass Authorization headers from HTTP requests
+/// to MCP services via RequestContext extensions. This enables MCP services
+/// to act as proxies, forwarding authentication tokens to backend APIs.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// // In an MCP service handler:
+/// use rmcp_actix_web::transport::AuthorizationHeader;
+///
+/// async fn handle_request(
+///     &self,
+///     request: SomeRequest,
+///     context: RequestContext<RoleServer>,
+/// ) -> Result<Response, McpError> {
+///     // Extract the Authorization header if present
+///     if let Some(auth) = context.extensions.get::<AuthorizationHeader>() {
+///         // Use auth.0 to access the header value (e.g., "Bearer token123")
+///         let token = &auth.0;
+///         // Forward to backend API...
+///     }
+///     // ...
+/// }
+/// ```
+#[derive(Clone, Debug)]
+pub struct AuthorizationHeader(pub String);

--- a/api/vendor/rmcp-actix-web/src/transport/streamable_http_server.rs
+++ b/api/vendor/rmcp-actix-web/src/transport/streamable_http_server.rs
@@ -1,0 +1,1352 @@
+//! Streamable HTTP transport implementation for MCP.
+//!
+//! This module provides a bidirectional HTTP transport with session management,
+//! supporting both request/response and streaming patterns for MCP communication.
+//!
+//! ## Architecture
+//!
+//! The transport uses three HTTP methods on a single endpoint:
+//! - **GET**: Resume or open SSE stream to receive server-to-client messages
+//! - **POST**: Send JSON-RPC requests (returns SSE stream with responses)
+//! - **DELETE**: Close session and cleanup resources
+//!
+//! ## Features
+//!
+//! - Full bidirectional communication
+//! - Session management with pluggable backends
+//! - Support for both streaming and request/response patterns
+//! - Efficient message routing
+//! - Graceful connection handling
+//!
+//! ## Session Management
+//!
+//! The transport supports different session managers:
+//! - `LocalSessionManager`: In-memory session storage (default)
+//! - Custom implementations via the `SessionManager` trait
+//!
+//! ## Example
+//!
+//! ```rust,no_run
+//! use rmcp_actix_web::transport::StreamableHttpService;
+//! use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+//! use actix_web::{App, HttpServer};
+//! use std::sync::Arc;
+//!
+//! # use rmcp::{ServerHandler, model::ServerInfo};
+//! # #[derive(Clone)]
+//! # struct MyService;
+//! # impl ServerHandler for MyService {
+//! #     fn get_info(&self) -> ServerInfo { ServerInfo::default() }
+//! # }
+//! # impl MyService { fn new() -> Self { Self } }
+//! #[actix_web::main]
+//! async fn main() -> std::io::Result<()> {
+//!     // Create service OUTSIDE HttpServer::new() to share across workers
+//!     let service = StreamableHttpService::builder()
+//!         .service_factory(Arc::new(|| Ok(MyService::new())))
+//!         .session_manager(Arc::new(LocalSessionManager::default()))
+//!         .stateful_mode(true)
+//!         .build();
+//!
+//!     HttpServer::new(move || {
+//!         App::new()
+//!             // Clone service for each worker (shares the same LocalSessionManager)
+//!             .service(service.clone().scope())
+//!     })
+//!     .bind("127.0.0.1:8080")?
+//!     .run()
+//!     .await
+//! }
+//! ```
+
+use std::{collections::HashMap, sync::Arc, time::Duration};
+
+use actix_web::{
+    HttpRequest, HttpResponse, Result, Scope,
+    error::InternalError,
+    http::{
+        StatusCode,
+        header::{self, CACHE_CONTROL},
+    },
+    middleware,
+    web::{self, Bytes, Data},
+};
+use futures::{Stream, StreamExt};
+use tokio::sync::watch;
+use tokio_stream::wrappers::ReceiverStream;
+
+/// Type alias for the on_request hook function.
+///
+/// This hook is called for each incoming request, allowing users to propagate
+/// typed extensions from the actix-web `HttpRequest` to rmcp's `RequestContext::extensions`.
+pub type OnRequestHook = dyn Fn(&HttpRequest, &mut rmcp::model::Extensions) + Send + Sync + 'static;
+
+use rmcp::{
+    RoleServer,
+    model::{
+        ClientJsonRpcMessage, ClientNotification, ClientRequest, InitializeRequest,
+        InitializedNotification, NumberOrString,
+    },
+    serve_server,
+    service::serve_directly,
+    transport::{
+        OneshotTransport, TransportAdapterIdentity,
+        common::http_header::{HEADER_LAST_EVENT_ID, HEADER_SESSION_ID},
+        streamable_http_server::session::{
+            RestoreOutcome, SessionId, SessionManager, SessionState, SessionStore,
+        },
+    },
+};
+
+use rmcp::model::GetExtensions;
+
+#[cfg(feature = "authorization-token-passthrough")]
+use super::AuthorizationHeader;
+
+// Local constants
+const HEADER_X_ACCEL_BUFFERING: &str = "X-Accel-Buffering";
+const EVENT_STREAM_MIME_TYPE: &str = "text/event-stream";
+const JSON_MIME_TYPE: &str = "application/json";
+
+/// Configuration for the streamable HTTP server transport.
+///
+/// Contains settings for session management and connection behavior.
+#[derive(Debug, Clone)]
+pub struct StreamableHttpServerConfig {
+    /// Whether to enable stateful session management
+    pub stateful_mode: bool,
+    /// Optional keep-alive interval for SSE connections
+    pub sse_keep_alive: Option<Duration>,
+}
+
+impl Default for StreamableHttpServerConfig {
+    fn default() -> Self {
+        Self {
+            stateful_mode: true,
+            sse_keep_alive: None,
+        }
+    }
+}
+
+/// Streamable HTTP transport service for actix-web integration.
+///
+/// Provides bidirectional MCP communication over HTTP with session management.
+/// This service can be integrated into existing actix-web applications.
+/// Uses a builder pattern for configuration.
+///
+/// # Type Parameters
+///
+/// * `S` - The MCP service type that handles protocol messages
+/// * `M` - The session manager type (defaults to `LocalSessionManager`)
+///
+/// # Architecture
+///
+/// The service manages endpoints with multiple HTTP methods:
+/// - GET: For streaming event connections
+/// - POST: For sending messages and creating sessions
+/// - DELETE: For closing sessions
+///
+/// Each client is identified by a session ID that must be provided in request headers.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use rmcp_actix_web::transport::StreamableHttpService;
+/// use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+/// use actix_web::{App, HttpServer, web};
+/// use std::{sync::Arc, time::Duration};
+///
+/// # use rmcp::{ServerHandler, model::ServerInfo};
+/// # #[derive(Clone)]
+/// # struct MyService;
+/// # impl ServerHandler for MyService {
+/// #     fn get_info(&self) -> ServerInfo { ServerInfo::default() }
+/// # }
+/// # impl MyService { fn new() -> Self { Self } }
+/// #[actix_web::main]
+/// async fn main() -> std::io::Result<()> {
+///     // Create service OUTSIDE HttpServer::new() to share across workers
+///     let service = StreamableHttpService::builder()
+///         .service_factory(Arc::new(|| Ok(MyService::new())))
+///         .session_manager(Arc::new(LocalSessionManager::default()))
+///         .stateful_mode(true)
+///         .sse_keep_alive(Duration::from_secs(30))
+///         .build();
+///
+///     HttpServer::new(move || {
+///         App::new()
+///             // Clone service for each worker (shares the same LocalSessionManager)
+///             .service(web::scope("/mcp").service(service.clone().scope()))
+///     })
+///     .bind("127.0.0.1:8080")?
+///     .run()
+///     .await
+/// }
+/// ```
+#[derive(bon::Builder)]
+pub struct StreamableHttpService<
+    S,
+    M = rmcp::transport::streamable_http_server::session::local::LocalSessionManager,
+> {
+    /// The service factory function that creates new MCP service instances
+    service_factory: Arc<dyn Fn() -> Result<S, std::io::Error> + Send + Sync>,
+
+    /// The session manager for tracking client connections
+    session_manager: Arc<M>,
+
+    /// Whether to enable stateful session management
+    #[builder(default = true)]
+    stateful_mode: bool,
+
+    /// Optional keep-alive interval for SSE connections
+    sse_keep_alive: Option<Duration>,
+
+    /// Optional hook called for each request to propagate extensions from HttpRequest to RequestContext.
+    ///
+    /// This allows middleware-populated data (e.g., JWT claims) to be accessed in MCP handlers.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use std::sync::Arc;
+    /// use actix_web::HttpMessage;
+    ///
+    /// StreamableHttpService::builder()
+    ///     .on_request(Arc::new(|http_req, ext| {
+    ///         if let Some(claims) = http_req.extensions().get::<MyClaims>() {
+    ///             ext.insert(claims.clone());
+    ///         }
+    ///     }))
+    ///     .build()
+    /// ```
+    on_request: Option<Arc<OnRequestHook>>,
+
+    /// Optional external session store for cross-instance recovery (rmcp >= 1.6).
+    ///
+    /// When set, the client's `initialize` parameters are persisted to the
+    /// store after a successful handshake. If a later request lands on a
+    /// different instance whose `LocalSessionManager` does not know the
+    /// session, the store is consulted and the handshake replayed
+    /// transparently — the client never observes the pod hop.
+    session_store: Option<Arc<dyn SessionStore>>,
+
+    /// In-flight restore deduplication map.
+    ///
+    /// Allocated lazily at the builder; shared via `Arc` across clones so
+    /// concurrent restores for the same session ID on different actix workers
+    /// are serialized into a single replay.
+    #[builder(default = Arc::new(tokio::sync::RwLock::new(HashMap::new())))]
+    pending_restores: Arc<tokio::sync::RwLock<HashMap<SessionId, watch::Sender<Option<bool>>>>>,
+}
+
+impl<S, M> Clone for StreamableHttpService<S, M> {
+    fn clone(&self) -> Self {
+        Self {
+            service_factory: self.service_factory.clone(),
+            session_manager: self.session_manager.clone(),
+            stateful_mode: self.stateful_mode,
+            sse_keep_alive: self.sse_keep_alive,
+            on_request: self.on_request.clone(),
+            session_store: self.session_store.clone(),
+            pending_restores: self.pending_restores.clone(),
+        }
+    }
+}
+
+// Convenience methods for StreamableHttpServiceBuilder
+impl<S, M, State: streamable_http_service_builder::State> StreamableHttpServiceBuilder<S, M, State>
+where
+    State::OnRequest: streamable_http_service_builder::IsUnset,
+{
+    /// Sets the on_request hook using a closure.
+    ///
+    /// This is a convenience method that automatically wraps the closure in an `Arc`,
+    /// making it easier to use without manual Arc wrapping.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use actix_web::HttpMessage;
+    ///
+    /// StreamableHttpService::builder()
+    ///     .on_request_fn(|http_req, ext| {
+    ///         if let Some(claims) = http_req.extensions().get::<MyClaims>() {
+    ///             ext.insert(claims.clone());
+    ///         }
+    ///     })
+    ///     .build()
+    /// ```
+    pub fn on_request_fn(
+        self,
+        hook: impl Fn(&HttpRequest, &mut rmcp::model::Extensions) + Send + Sync + 'static,
+    ) -> StreamableHttpServiceBuilder<S, M, streamable_http_service_builder::SetOnRequest<State>>
+    {
+        self.on_request(Arc::new(hook))
+    }
+}
+
+/// Internal data structure used by handlers to store service configuration
+/// with Arc-wrapped session manager for thread safety.
+#[derive(Clone)]
+struct AppData<S, M> {
+    /// The service factory function that creates new MCP service instances
+    service_factory: Arc<dyn Fn() -> Result<S, std::io::Error> + Send + Sync>,
+    /// The session manager wrapped in Arc for thread safety
+    session_manager: Arc<M>,
+    /// Whether the service operates in stateful mode
+    stateful_mode: bool,
+    /// Optional keep-alive interval for SSE connections
+    sse_keep_alive: Option<Duration>,
+    /// Optional hook for propagating extensions from HttpRequest to RequestContext
+    on_request: Option<Arc<OnRequestHook>>,
+    /// Optional external session store for cross-instance recovery
+    session_store: Option<Arc<dyn SessionStore>>,
+    /// Shared in-flight restore deduplication map
+    pending_restores: Arc<tokio::sync::RwLock<HashMap<SessionId, watch::Sender<Option<bool>>>>>,
+}
+
+impl<S, M> AppData<S, M> {
+    fn get_service(&self) -> Result<S, std::io::Error> {
+        (self.service_factory)()
+    }
+}
+
+// SSE Stream Helper Functions
+//
+// These functions provide reusable SSE keep-alive functionality to avoid code duplication.
+
+/// Wraps any SSE-formatted stream with keep-alive ping support.
+///
+/// Adds periodic `:ping\n\n` messages during silent periods to prevent connection timeouts.
+/// The wrapper automatically stops when the underlying stream ends, allowing POST responses
+/// to close properly per MCP spec.
+///
+/// # Arguments
+///
+/// * `stream` - A stream of SSE-formatted bytes (already formatted as `data: ...\n\n`)
+/// * `keep_alive` - Optional keep-alive interval. If `Some`, sends `:ping\n\n` at this interval
+///   during silent periods. If `None`, no pings are sent.
+///
+/// # Returns
+///
+/// A stream that multiplexes the input stream with keep-alive pings, ending when the input ends.
+fn wrap_with_sse_keepalive<S>(
+    stream: S,
+    keep_alive: Option<Duration>,
+) -> impl Stream<Item = Result<Bytes, actix_web::Error>>
+where
+    S: Stream<Item = Result<Bytes, actix_web::Error>> + Send + 'static,
+{
+    async_stream::stream! {
+        let mut stream = Box::pin(stream);
+        let mut keep_alive_timer = keep_alive.map(|duration| tokio::time::interval(duration));
+
+        // Consume the immediate first tick if keep-alive is enabled
+        if let Some(ref mut timer) = keep_alive_timer {
+            timer.tick().await;
+        }
+
+        loop {
+            tokio::select! {
+                result = stream.next() => {
+                    match result {
+                        Some(msg) => yield msg,
+                        None => break, // Stream ended, stop sending pings
+                    }
+                }
+                _ = async {
+                    match keep_alive_timer.as_mut() {
+                        Some(timer) => {
+                            timer.tick().await;
+                        }
+                        None => {
+                            std::future::pending::<()>().await;
+                        }
+                    }
+                } => {
+                    yield Ok(Bytes::from(":ping\n\n"));
+                }
+            }
+        }
+    }
+}
+
+impl<S, M> StreamableHttpService<S, M>
+where
+    S: Clone + rmcp::ServerHandler + Send + 'static,
+    M: SessionManager + 'static,
+{
+    /// Creates a new scope configured with this service for framework-level composition.
+    ///
+    /// This method provides framework-level composition aligned with RMCP patterns,
+    /// similar to how `SseService::scope()` works. This allows mounting the
+    /// streamable HTTP service at custom paths using actix-web's routing.
+    ///
+    /// The method consumes `self`, so you can call it directly on the service instance.
+    /// If you need to use the service multiple times, wrap it in an `Arc` and clone it.
+    ///
+    /// This method is equivalent to `scope_with_path("")`.
+    ///
+    /// # Returns
+    ///
+    /// Returns an actix-web `Scope` configured with the streamable HTTP routes
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use rmcp_actix_web::transport::StreamableHttpService;
+    /// use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+    /// use actix_web::{App, HttpServer, web};
+    /// use std::sync::Arc;
+    ///
+    /// # use rmcp::{ServerHandler, model::ServerInfo};
+    /// # #[derive(Clone)]
+    /// # struct MyService;
+    /// # impl ServerHandler for MyService {
+    /// #     fn get_info(&self) -> ServerInfo { ServerInfo::default() }
+    /// # }
+    /// # impl MyService { fn new() -> Self { Self } }
+    /// #[actix_web::main]
+    /// async fn main() -> std::io::Result<()> {
+    ///     // Create service OUTSIDE HttpServer::new() to share across workers
+    ///     let service = StreamableHttpService::builder()
+    ///         .service_factory(Arc::new(|| Ok(MyService::new())))
+    ///         .session_manager(Arc::new(LocalSessionManager::default()))
+    ///         .build();
+    ///
+    ///     HttpServer::new(move || {
+    ///         App::new()
+    ///             // Clone service for each worker (shares the same LocalSessionManager)
+    ///             .service(web::scope("/api/v1/mcp").service(service.clone().scope()))
+    ///     })
+    ///     .bind("127.0.0.1:8080")?
+    ///     .run();
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn scope(
+        self,
+    ) -> Scope<
+        impl actix_web::dev::ServiceFactory<
+            actix_web::dev::ServiceRequest,
+            Config = (),
+            Response = actix_web::dev::ServiceResponse,
+            Error = actix_web::Error,
+            InitError = (),
+        >,
+    > {
+        self.scope_with_path("")
+    }
+
+    /// Creates a new scope configured with this service for framework-level composition.
+    ///
+    /// This method provides framework-level composition aligned with RMCP patterns,
+    /// similar to how `SseService::scope()` works. This allows mounting the
+    /// streamable HTTP service at custom paths using actix-web's routing.
+    ///
+    /// The method consumes `self`, so you can call it directly on the service instance.
+    /// If you need to use the service multiple times, wrap it in an `Arc` and clone it.
+    ///
+    /// This method is similar to `scope` except that it allows specifying a custom path.
+    ///
+    /// # Returns
+    ///
+    /// Returns an actix-web `Scope` configured with the streamable HTTP routes
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use rmcp_actix_web::transport::{StreamableHttpService, AuthorizationHeader};
+    /// use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+    /// use actix_web::{App, HttpServer, web};
+    /// use std::sync::Arc;
+    ///
+    /// # use rmcp::{ServerHandler, model::ServerInfo};
+    /// # #[derive(Clone)]
+    /// # struct MyService;
+    /// # impl ServerHandler for MyService {
+    /// #     fn get_info(&self) -> ServerInfo { ServerInfo::default() }
+    /// # }
+    /// # impl MyService { fn new() -> Self { Self } }
+    /// #[actix_web::main]
+    /// async fn main() -> std::io::Result<()> {
+    ///     // Create service OUTSIDE HttpServer::new() to share across workers
+    ///     let service = StreamableHttpService::builder()
+    ///         .service_factory(Arc::new(|| Ok(MyService::new())))
+    ///         .session_manager(Arc::new(LocalSessionManager::default()))
+    ///         .build();
+    ///
+    ///     HttpServer::new(move || {
+    ///         App::new()
+    ///             // Clone service for each worker (shares the same LocalSessionManager)
+    ///             .service(service.clone().scope_with_path("/api/v1/mcp"))
+    ///     })
+    ///     .bind("127.0.0.1:8080")?
+    ///     .run();
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn scope_with_path(
+        self,
+        path: &str,
+    ) -> Scope<
+        impl actix_web::dev::ServiceFactory<
+            actix_web::dev::ServiceRequest,
+            Config = (),
+            Response = actix_web::dev::ServiceResponse,
+            Error = actix_web::Error,
+            InitError = (),
+        >,
+    > {
+        let app_data = AppData {
+            service_factory: self.service_factory,
+            session_manager: self.session_manager,
+            stateful_mode: self.stateful_mode,
+            sse_keep_alive: self.sse_keep_alive,
+            on_request: self.on_request,
+            session_store: self.session_store,
+            pending_restores: self.pending_restores,
+        };
+
+        web::scope(path)
+            .app_data(Data::new(app_data))
+            .wrap(middleware::NormalizePath::trim())
+            .route("", web::get().to(Self::handle_get))
+            .route("", web::post().to(Self::handle_post))
+            .route("", web::delete().to(Self::handle_delete))
+    }
+
+    async fn handle_get(req: HttpRequest, service: Data<AppData<S, M>>) -> Result<HttpResponse> {
+        // Check accept header
+        let accept = req
+            .headers()
+            .get(header::ACCEPT)
+            .and_then(|h| h.to_str().ok());
+
+        if !accept.is_some_and(|header| header.contains(EVENT_STREAM_MIME_TYPE)) {
+            return Ok(HttpResponse::NotAcceptable()
+                .body("Not Acceptable: Client must accept text/event-stream"));
+        }
+
+        // Check session id
+        let session_id = req
+            .headers()
+            .get(HEADER_SESSION_ID)
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_owned().into());
+
+        let Some(session_id) = session_id else {
+            return Ok(HttpResponse::Unauthorized().body("Unauthorized: Session ID is required"));
+        };
+
+        tracing::debug!(%session_id, "GET request for SSE stream");
+
+        // Check if session exists
+        let has_session = service
+            .session_manager
+            .has_session(&session_id)
+            .await
+            .map_err(|e| InternalError::new(e, StatusCode::INTERNAL_SERVER_ERROR))?;
+
+        if !has_session {
+            // Attempt transparent cross-instance restore from external store.
+            // On miss, the MCP spec mandates 404 (not 401) so the client
+            // re-initializes cleanly instead of looping on token refresh.
+            let restored = try_restore_from_store(&service, &session_id, &req)
+                .await
+                .map_err(|e| InternalError::new(e, StatusCode::INTERNAL_SERVER_ERROR))?;
+            if !restored {
+                return Ok(HttpResponse::NotFound().body("Not Found: Session not found"));
+            }
+        }
+
+        // Check if last event id is provided
+        let last_event_id = req
+            .headers()
+            .get(HEADER_LAST_EVENT_ID)
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_owned());
+
+        // Get the appropriate stream
+        let sse_stream: std::pin::Pin<Box<dyn Stream<Item = _> + Send>> =
+            if let Some(last_event_id) = last_event_id {
+                tracing::debug!(%session_id, %last_event_id, "Resuming stream from last event");
+                Box::pin(
+                    service
+                        .session_manager
+                        .resume(&session_id, last_event_id)
+                        .await
+                        .map_err(|e| InternalError::new(e, StatusCode::INTERNAL_SERVER_ERROR))?,
+                )
+            } else {
+                tracing::debug!(%session_id, "Creating standalone stream");
+                Box::pin(
+                    service
+                        .session_manager
+                        .create_standalone_stream(&session_id)
+                        .await
+                        .map_err(|e| InternalError::new(e, StatusCode::INTERNAL_SERVER_ERROR))?,
+                )
+            };
+
+        // Convert to SSE format and add keep-alive
+        let formatted_stream = sse_stream.map(|msg| {
+            let data = serde_json::to_string(&msg.message).unwrap_or_else(|_| "{}".to_string());
+            let mut output = String::new();
+            if let Some(id) = msg.event_id {
+                output.push_str(&format!("id: {id}\n"));
+            }
+            output.push_str(&format!("data: {data}\n\n"));
+            Ok::<_, actix_web::Error>(Bytes::from(output))
+        });
+        let sse_stream = wrap_with_sse_keepalive(formatted_stream, service.sse_keep_alive);
+
+        Ok(HttpResponse::Ok()
+            .content_type(EVENT_STREAM_MIME_TYPE)
+            .append_header((CACHE_CONTROL, "no-cache"))
+            .append_header((HEADER_X_ACCEL_BUFFERING, "no"))
+            .streaming(sse_stream))
+    }
+
+    async fn handle_post(
+        req: HttpRequest,
+        body: Bytes,
+        service: Data<AppData<S, M>>,
+    ) -> Result<HttpResponse> {
+        // Check accept header
+        let accept = req
+            .headers()
+            .get(header::ACCEPT)
+            .and_then(|h| h.to_str().ok());
+
+        if !accept.is_some_and(|header| {
+            header.contains(JSON_MIME_TYPE) && header.contains(EVENT_STREAM_MIME_TYPE)
+        }) {
+            return Ok(HttpResponse::NotAcceptable().body(
+                "Not Acceptable: Client must accept both application/json and text/event-stream",
+            ));
+        }
+
+        // Check content type
+        let content_type = req
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|h| h.to_str().ok());
+
+        if !content_type.is_some_and(|header| header.starts_with(JSON_MIME_TYPE)) {
+            return Ok(HttpResponse::UnsupportedMediaType()
+                .body("Unsupported Media Type: Content-Type must be application/json"));
+        }
+
+        // Deserialize the message
+        let mut message: ClientJsonRpcMessage = serde_json::from_slice(&body)
+            .map_err(|e| InternalError::new(e, StatusCode::BAD_REQUEST))?;
+
+        tracing::debug!(?message, "POST request with message");
+
+        if service.stateful_mode {
+            // Check session id
+            let session_id = req
+                .headers()
+                .get(HEADER_SESSION_ID)
+                .and_then(|v| v.to_str().ok());
+
+            if let Some(session_id) = session_id {
+                let session_id = session_id.to_owned().into();
+                tracing::debug!(%session_id, "POST request with existing session");
+
+                let has_session = service
+                    .session_manager
+                    .has_session(&session_id)
+                    .await
+                    .map_err(|e| InternalError::new(e, StatusCode::INTERNAL_SERVER_ERROR))?;
+
+                if !has_session {
+                    // Attempt transparent cross-instance restore from external store.
+                    let restored = try_restore_from_store(&service, &session_id, &req)
+                        .await
+                        .map_err(|e| InternalError::new(e, StatusCode::INTERNAL_SERVER_ERROR))?;
+                    if !restored {
+                        tracing::warn!(%session_id, "Session not found");
+                        return Ok(HttpResponse::NotFound().body("Not Found: Session not found"));
+                    }
+                }
+
+                // Note: In actix-web we can't inject request parts like in tower,
+                // but session_id is already available through headers
+
+                match message {
+                    #[allow(unused_mut)]
+                    ClientJsonRpcMessage::Request(mut request_msg) => {
+                        // Call on_request hook to propagate extensions from HttpRequest
+                        if let Some(ref hook) = service.on_request {
+                            hook(&req, request_msg.request.extensions_mut());
+                        }
+
+                        // Extract and inject Authorization header for existing sessions.
+                        //
+                        // SECURITY: This transport forwards Authorization headers to MCP services.
+                        //
+                        // MCP-COMPLIANT USAGE: MCP services MUST validate these tokens as intended for themselves
+                        // and MUST NOT forward them to upstream APIs (per MCP specification).
+                        //
+                        // NON-COMPLIANT USAGE: Some implementations (e.g., rmcp-openapi-server) use these tokens
+                        // for upstream API authentication. This violates MCP specifications but may be necessary
+                        // for certain proxy architectures. Use with caution and ensure proper token audience validation.
+                        // See SECURITY.md for details.
+                        //
+                        // Supports OAuth 2.1 token rotation patterns by forwarding each request's
+                        // Authorization independently. This enables:
+                        // - Token rotation within sessions (security best practice)
+                        // - Token refresh when access tokens expire
+                        // - Scope changes for different operations within the same session
+                        //
+                        // The proxy does NOT cache or reuse tokens from session initialization.
+                        // Each request must provide its own valid Authorization header.
+                        #[cfg(feature = "authorization-token-passthrough")]
+                        if let Some(auth_value) = req.headers().get(header::AUTHORIZATION) {
+                            match auth_value.to_str() {
+                                Ok(auth_str)
+                                    if auth_str.starts_with("Bearer ") && auth_str.len() > 7 =>
+                                {
+                                    tracing::debug!(
+                                        "Forwarding Authorization header to MCP service for existing session. \
+                                         Note: MCP services must not pass this token to upstream APIs per MCP spec. \
+                                         See SECURITY.md for details."
+                                    );
+                                    request_msg
+                                        .request
+                                        .extensions_mut()
+                                        .insert(AuthorizationHeader(auth_str.to_string()));
+                                }
+                                Ok(auth_str) if auth_str == "Bearer" || auth_str == "Bearer " => {
+                                    tracing::debug!(
+                                        "Malformed Bearer token in existing session: missing token value"
+                                    );
+                                }
+                                Ok(auth_str) if !auth_str.starts_with("Bearer ") => {
+                                    let auth_type =
+                                        auth_str.split_whitespace().next().unwrap_or("unknown");
+                                    tracing::warn!(
+                                        "Non-Bearer authorization header ignored for existing session: {}",
+                                        auth_type
+                                    );
+                                }
+                                Err(e) => {
+                                    tracing::debug!(
+                                        "Invalid Authorization header encoding in existing session: {}",
+                                        e
+                                    );
+                                }
+                                _ => {}
+                            }
+                        }
+
+                        #[cfg(not(feature = "authorization-token-passthrough"))]
+                        if req.headers().get(header::AUTHORIZATION).is_some() {
+                            tracing::warn!(
+                                "Authorization header present but not forwarded. \
+                                 Enable 'authorization-token-passthrough' feature to forward tokens to MCP services. \
+                                 Note: Token passthrough violates MCP specifications. See SECURITY.md for details."
+                            );
+                        }
+
+                        let stream = service
+                            .session_manager
+                            .create_stream(&session_id, ClientJsonRpcMessage::Request(request_msg))
+                            .await
+                            .map_err(|e| {
+                                InternalError::new(e, StatusCode::INTERNAL_SERVER_ERROR)
+                            })?;
+
+                        // Convert to SSE format with keep-alive
+                        // Keep-alive prevents timeouts during long tool execution with no progress updates
+                        // Stream closes automatically after final response (keep-alive stops when stream ends)
+                        let formatted_stream = stream.map(|msg| {
+                            let data = serde_json::to_string(&msg.message)
+                                .unwrap_or_else(|_| "{}".to_string());
+                            let mut output = String::new();
+                            if let Some(id) = msg.event_id {
+                                output.push_str(&format!("id: {id}\n"));
+                            }
+                            output.push_str(&format!("data: {data}\n\n"));
+                            Ok::<_, actix_web::Error>(Bytes::from(output))
+                        });
+                        let sse_stream =
+                            wrap_with_sse_keepalive(formatted_stream, service.sse_keep_alive);
+
+                        Ok(HttpResponse::Ok()
+                            .content_type(EVENT_STREAM_MIME_TYPE)
+                            .append_header((CACHE_CONTROL, "no-cache"))
+                            .append_header((HEADER_X_ACCEL_BUFFERING, "no"))
+                            .streaming(sse_stream))
+                    }
+                    ClientJsonRpcMessage::Notification(_)
+                    | ClientJsonRpcMessage::Response(_)
+                    | ClientJsonRpcMessage::Error(_) => {
+                        // Handle notification
+                        service
+                            .session_manager
+                            .accept_message(&session_id, message)
+                            .await
+                            .map_err(|e| {
+                                InternalError::new(e, StatusCode::INTERNAL_SERVER_ERROR)
+                            })?;
+
+                        Ok(HttpResponse::Accepted().finish())
+                    }
+                }
+            } else {
+                // No session id in stateful mode - create new session
+                tracing::debug!("POST request without session, creating new session");
+
+                let (session_id, transport) = service
+                    .session_manager
+                    .create_session()
+                    .await
+                    .map_err(|e| InternalError::new(e, StatusCode::INTERNAL_SERVER_ERROR))?;
+
+                tracing::info!(%session_id, "Created new session");
+
+                // Capture init params for external store persistence before
+                // extensions are injected (which would force a Clone).
+                let stored_init_params = if service.session_store.is_some() {
+                    if let ClientJsonRpcMessage::Request(req) = &message {
+                        if let ClientRequest::InitializeRequest(init_req) = &req.request {
+                            Some(init_req.params.clone())
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
+
+                if let ClientJsonRpcMessage::Request(request_msg) = &mut message {
+                    if !matches!(request_msg.request, ClientRequest::InitializeRequest(_)) {
+                        return Ok(
+                            HttpResponse::UnprocessableEntity().body("Expected initialize request")
+                        );
+                    }
+
+                    // Call on_request hook to propagate extensions from HttpRequest
+                    if let Some(ref hook) = service.on_request {
+                        hook(&req, request_msg.request.extensions_mut());
+                    }
+
+                    // Extract and inject Authorization header if present
+                    //
+                    // SECURITY: This transport forwards Authorization headers to MCP services.
+                    //
+                    // MCP-COMPLIANT USAGE: MCP services MUST validate these tokens as intended for themselves
+                    // and MUST NOT forward them to upstream APIs (per MCP specification).
+                    //
+                    // NON-COMPLIANT USAGE: Some implementations (e.g., rmcp-openapi-server) use these tokens
+                    // for upstream API authentication. This violates MCP specifications but may be necessary
+                    // for certain proxy architectures. Use with caution and ensure proper token audience validation.
+                    // See SECURITY.md for details.
+                    #[cfg(feature = "authorization-token-passthrough")]
+                    if let Some(auth_value) = req.headers().get(header::AUTHORIZATION) {
+                        match auth_value.to_str() {
+                            Ok(auth_str)
+                                if auth_str.starts_with("Bearer ") && auth_str.len() > 7 =>
+                            {
+                                tracing::debug!(
+                                    "Forwarding Authorization header to MCP service for new session. \
+                                     Note: MCP services must not pass this token to upstream APIs per MCP spec. \
+                                     See SECURITY.md for details."
+                                );
+                                request_msg
+                                    .request
+                                    .extensions_mut()
+                                    .insert(AuthorizationHeader(auth_str.to_string()));
+                            }
+                            Ok(auth_str) if auth_str == "Bearer" || auth_str == "Bearer " => {
+                                tracing::debug!(
+                                    "Malformed Bearer token in new session: missing token value"
+                                );
+                            }
+                            Ok(auth_str) if !auth_str.starts_with("Bearer ") => {
+                                let auth_type =
+                                    auth_str.split_whitespace().next().unwrap_or("unknown");
+                                tracing::warn!(
+                                    "Non-Bearer authorization header ignored for new session: {}",
+                                    auth_type
+                                );
+                            }
+                            Err(e) => {
+                                tracing::debug!(
+                                    "Invalid Authorization header encoding in new session: {}",
+                                    e
+                                );
+                            }
+                            _ => {}
+                        }
+                    }
+
+                    #[cfg(not(feature = "authorization-token-passthrough"))]
+                    if req.headers().get(header::AUTHORIZATION).is_some() {
+                        tracing::warn!(
+                            "Authorization header present but not forwarded for new session. \
+                             Enable 'authorization-token-passthrough' feature to forward tokens to MCP services. \
+                             Note: Token passthrough violates MCP specifications. See SECURITY.md for details."
+                        );
+                    }
+                } else {
+                    return Ok(
+                        HttpResponse::UnprocessableEntity().body("Expected initialize request")
+                    );
+                }
+
+                let service_instance = service
+                    .get_service()
+                    .map_err(|e| InternalError::new(e, StatusCode::INTERNAL_SERVER_ERROR))?;
+
+                // Spawn a task to serve the session
+                tokio::spawn({
+                    let session_manager = service.session_manager.clone();
+                    let session_id = session_id.clone();
+                    async move {
+                        let service = serve_server::<S, M::Transport, _, TransportAdapterIdentity>(
+                            service_instance,
+                            transport,
+                        )
+                        .await;
+                        match service {
+                            Ok(service) => {
+                                let _ = service.waiting().await;
+                            }
+                            Err(e) => {
+                                tracing::error!("Failed to create service: {e}");
+                            }
+                        }
+                        let _ = session_manager
+                            .close_session(&session_id)
+                            .await
+                            .inspect_err(|e| {
+                                tracing::error!("Failed to close session {session_id}: {e}");
+                            });
+                    }
+                });
+
+                // Get initialize response
+                let response = service
+                    .session_manager
+                    .initialize_session(&session_id, message)
+                    .await
+                    .map_err(|e| InternalError::new(e, StatusCode::INTERNAL_SERVER_ERROR))?;
+
+                // Persist session state to external store after a successful handshake.
+                if let (Some(store), Some(params)) = (&service.session_store, stored_init_params) {
+                    let state = SessionState::new(params);
+                    let _ = store
+                        .store(session_id.as_ref(), &state)
+                        .await
+                        .inspect_err(|e| {
+                            tracing::warn!(
+                                "Failed to persist session {} to store: {e}",
+                                session_id
+                            );
+                        });
+                }
+
+                tracing::debug!(?response, "Initialization complete, creating SSE stream");
+
+                // Return SSE stream with initialization response (no keep-alive)
+                // Per MCP spec: "After the JSON-RPC response has been sent, the server SHOULD close the SSE stream"
+                // Initialization completes with a single response, so no keep-alive needed
+                let sse_stream = async_stream::stream! {
+                    yield Ok::<_, actix_web::Error>(Bytes::from(format!(
+                        "data: {}\n\n",
+                        serde_json::to_string(&response).unwrap_or_else(|_| "{}".to_string())
+                    )));
+                };
+                tracing::debug!("Created initialization response stream (closes after response)");
+
+                tracing::info!(
+                    ?session_id,
+                    "Returning SSE streaming response for initialization"
+                );
+                Ok(HttpResponse::Ok()
+                    .content_type(EVENT_STREAM_MIME_TYPE)
+                    .append_header((CACHE_CONTROL, "no-cache"))
+                    .append_header((HEADER_X_ACCEL_BUFFERING, "no"))
+                    .append_header((HEADER_SESSION_ID, session_id.as_ref()))
+                    .streaming(sse_stream))
+            }
+        } else {
+            // Stateless mode
+            tracing::debug!("POST request in stateless mode");
+
+            match message {
+                #[allow(unused_mut)]
+                ClientJsonRpcMessage::Request(mut request) => {
+                    tracing::debug!(?request, "Processing request in stateless mode");
+
+                    // Call on_request hook to propagate extensions from HttpRequest
+                    if let Some(ref hook) = service.on_request {
+                        hook(&req, request.request.extensions_mut());
+                    }
+
+                    // Extract and inject Authorization header if present
+                    //
+                    // SECURITY: This transport forwards Authorization headers to MCP services.
+                    //
+                    // MCP-COMPLIANT USAGE: MCP services MUST validate these tokens as intended for themselves
+                    // and MUST NOT forward them to upstream APIs (per MCP specification).
+                    //
+                    // NON-COMPLIANT USAGE: Some implementations (e.g., rmcp-openapi-server) use these tokens
+                    // for upstream API authentication. This violates MCP specifications but may be necessary
+                    // for certain proxy architectures. Use with caution and ensure proper token audience validation.
+                    // See SECURITY.md for details.
+                    #[cfg(feature = "authorization-token-passthrough")]
+                    if let Some(auth_value) = req.headers().get(header::AUTHORIZATION) {
+                        match auth_value.to_str() {
+                            Ok(auth_str)
+                                if auth_str.starts_with("Bearer ") && auth_str.len() > 7 =>
+                            {
+                                tracing::debug!(
+                                    "Forwarding Authorization header to MCP service in stateless mode. \
+                                     Note: MCP services must not pass this token to upstream APIs per MCP spec. \
+                                     See SECURITY.md for details."
+                                );
+                                request
+                                    .request
+                                    .extensions_mut()
+                                    .insert(AuthorizationHeader(auth_str.to_string()));
+                            }
+                            Ok(auth_str) if auth_str == "Bearer" || auth_str == "Bearer " => {
+                                tracing::debug!(
+                                    "Malformed Bearer token in stateless mode: missing token value"
+                                );
+                            }
+                            Ok(auth_str) if !auth_str.starts_with("Bearer ") => {
+                                let auth_type =
+                                    auth_str.split_whitespace().next().unwrap_or("unknown");
+                                tracing::warn!(
+                                    "Non-Bearer authorization header ignored in stateless mode: {}",
+                                    auth_type
+                                );
+                            }
+                            Err(e) => {
+                                tracing::debug!(
+                                    "Invalid Authorization header encoding in stateless mode: {}",
+                                    e
+                                );
+                            }
+                            _ => {}
+                        }
+                    }
+
+                    #[cfg(not(feature = "authorization-token-passthrough"))]
+                    if req.headers().get(header::AUTHORIZATION).is_some() {
+                        tracing::warn!(
+                            "Authorization header present but not forwarded in stateless mode. \
+                             Enable 'authorization-token-passthrough' feature to forward tokens to MCP services. \
+                             Note: Token passthrough violates MCP specifications. See SECURITY.md for details."
+                        );
+                    }
+
+                    // In stateless mode, handle the request directly
+                    let service_instance = service
+                        .get_service()
+                        .map_err(|e| InternalError::new(e, StatusCode::INTERNAL_SERVER_ERROR))?;
+
+                    let (transport, receiver) =
+                        OneshotTransport::<RoleServer>::new(ClientJsonRpcMessage::Request(request));
+                    let service_handle = serve_directly(service_instance, transport, None);
+
+                    tokio::spawn(async move {
+                        // Let the service process the request
+                        let _ = service_handle.waiting().await;
+                    });
+
+                    // Convert receiver stream to SSE format with keep-alive
+                    // Keep-alive prevents timeouts during long tool execution with no progress updates
+                    // Stream closes automatically after final response (keep-alive stops when stream ends)
+                    let formatted_stream = ReceiverStream::new(receiver).map(|message| {
+                        tracing::info!(?message);
+                        let data =
+                            serde_json::to_string(&message).unwrap_or_else(|_| "{}".to_string());
+                        Ok::<_, actix_web::Error>(Bytes::from(format!("data: {data}\n\n")))
+                    });
+                    let sse_stream =
+                        wrap_with_sse_keepalive(formatted_stream, service.sse_keep_alive);
+
+                    Ok(HttpResponse::Ok()
+                        .content_type(EVENT_STREAM_MIME_TYPE)
+                        .append_header((CACHE_CONTROL, "no-cache"))
+                        .append_header((HEADER_X_ACCEL_BUFFERING, "no"))
+                        .streaming(sse_stream))
+                }
+                _ => Ok(HttpResponse::UnprocessableEntity().body("Unexpected message type")),
+            }
+        }
+    }
+
+    async fn handle_delete(req: HttpRequest, service: Data<AppData<S, M>>) -> Result<HttpResponse> {
+        // Check session id
+        let session_id = req
+            .headers()
+            .get(HEADER_SESSION_ID)
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_owned().into());
+
+        let Some(session_id) = session_id else {
+            return Ok(HttpResponse::Unauthorized().body("Unauthorized: Session ID is required"));
+        };
+
+        tracing::debug!(%session_id, "DELETE request to close session");
+
+        // Close session
+        service
+            .session_manager
+            .close_session(&session_id)
+            .await
+            .map_err(|e| InternalError::new(e, StatusCode::INTERNAL_SERVER_ERROR))?;
+
+        // Remove from external store: a DELETE means the client intentionally
+        // ends the session, so the store entry is no longer needed.
+        if let Some(store) = &service.session_store {
+            let _ = store.delete(session_id.as_ref()).await.inspect_err(|e| {
+                tracing::warn!("Failed to delete session {} from store: {e}", session_id);
+            });
+        }
+
+        tracing::info!(%session_id, "Session closed");
+
+        Ok(HttpResponse::NoContent().finish())
+    }
+}
+
+/// Guard used inside [`try_restore_from_store`].
+///
+/// Ensures the `pending_restores` map entry is always cleaned up — even when
+/// the future is cancelled mid-await. `result` defaults to `false` (failure /
+/// cancellation); only the success path sets it to `true` before returning.
+struct PendingRestoreGuard {
+    pending_restores: Arc<tokio::sync::RwLock<HashMap<SessionId, watch::Sender<Option<bool>>>>>,
+    session_id: SessionId,
+    watch_tx: watch::Sender<Option<bool>>,
+    result: bool,
+}
+
+impl Drop for PendingRestoreGuard {
+    fn drop(&mut self) {
+        let _ = self.watch_tx.send(Some(self.result));
+        let pending_restores = self.pending_restores.clone();
+        let session_id = self.session_id.clone();
+        tokio::spawn(async move {
+            pending_restores.write().await.remove(&session_id);
+        });
+    }
+}
+
+/// Spawn the rmcp `serve_server` task for a session and wire up close-on-end.
+///
+/// `init_done_tx`: when `Some`, fired after `serve_server` returns successfully,
+/// signalling to the caller that the MCP handshake is ready. `try_restore_from_store`
+/// uses this to synchronise with the restore handshake; the normal initialize
+/// path passes `None`.
+fn spawn_session_worker<S, M>(
+    session_manager: Arc<M>,
+    session_id: SessionId,
+    service_instance: S,
+    transport: M::Transport,
+    init_done_tx: Option<tokio::sync::oneshot::Sender<()>>,
+) where
+    S: rmcp::ServerHandler + Send + 'static,
+    M: SessionManager + 'static,
+{
+    tokio::spawn(async move {
+        let svc =
+            serve_server::<S, M::Transport, _, TransportAdapterIdentity>(service_instance, transport)
+                .await;
+        match svc {
+            Ok(svc) => {
+                if let Some(tx) = init_done_tx {
+                    let _ = tx.send(());
+                }
+                let _ = svc.waiting().await;
+            }
+            Err(e) => {
+                tracing::error!("Failed to serve session: {e}");
+                // Dropping init_done_tx (if Some) signals failure to the caller.
+            }
+        }
+        let _ = session_manager
+            .close_session(&session_id)
+            .await
+            .inspect_err(|e| {
+                tracing::error!("Failed to close session {session_id}: {e}");
+            });
+    });
+}
+
+/// Attempt to restore a session from the external store and replay the MCP
+/// handshake against the local session manager.
+///
+/// Returns `true` when the session is available and ready to serve the current
+/// request. Returns `false` when no store is configured, the session ID is
+/// unknown to the store, or the underlying session manager does not support
+/// restore.
+///
+/// Concurrent requests for the same unknown session ID are serialized: the
+/// first caller performs the full restore + handshake replay while others
+/// subscribe to a `watch` channel and wait, avoiding duplicate handshakes.
+///
+/// Adapted from rmcp 1.6's `tower::StreamableHttpService::try_restore_from_store`
+/// (`crates/rmcp/src/transport/streamable_http_server/tower.rs`). The actix
+/// version uses the existing `on_request` hook to populate the synthesized
+/// `initialize` / `initialized` message extensions instead of cloning
+/// `http::request::Parts`, since actix middleware (e.g. our auth layer)
+/// already populates the actix request's extensions.
+async fn try_restore_from_store<S, M>(
+    service: &AppData<S, M>,
+    session_id: &SessionId,
+    req: &HttpRequest,
+) -> std::result::Result<bool, std::io::Error>
+where
+    S: Clone + rmcp::ServerHandler + Send + 'static,
+    M: SessionManager + 'static,
+{
+    let Some(store) = &service.session_store else {
+        return Ok(false);
+    };
+
+    // Serialize concurrent restores for the same session ID.
+    let (watch_tx, _watch_rx) = watch::channel(None::<bool>);
+    {
+        let mut pending = service.pending_restores.write().await;
+        if let Some(tx) = pending.get(session_id) {
+            let mut rx = tx.subscribe();
+            drop(pending);
+            let result = rx
+                .wait_for(|r| r.is_some())
+                .await
+                .map(|r| r.unwrap_or(false))
+                .unwrap_or(false);
+            return Ok(result);
+        }
+        pending.insert(session_id.clone(), watch_tx.clone());
+    }
+
+    // Guard signals waiters and cleans up the pending_restores map entry on drop.
+    let mut guard = PendingRestoreGuard {
+        pending_restores: service.pending_restores.clone(),
+        session_id: session_id.clone(),
+        watch_tx: watch_tx.clone(),
+        result: false,
+    };
+
+    // Step 1: load from external store.
+    let state = match store.load(session_id.as_ref()).await {
+        Ok(Some(s)) => s,
+        Ok(None) => return Ok(false),
+        Err(e) => {
+            tracing::error!(
+                session_id = session_id.as_ref(),
+                error = %e,
+                "session store load failed during restore"
+            );
+            return Err(std::io::Error::other(e));
+        }
+    };
+
+    // Step 2: ask the session manager to allocate a fresh in-memory worker.
+    let transport = match service
+        .session_manager
+        .restore_session(session_id.clone())
+        .await
+        .map_err(|e| std::io::Error::other(e.to_string()))
+    {
+        Ok(RestoreOutcome::Restored(t)) => t,
+        Ok(RestoreOutcome::AlreadyPresent) => {
+            // Invariant violation: pending_restores ensures only one task can
+            // call restore_session per session ID, so AlreadyPresent is
+            // impossible here.
+            return Err(std::io::Error::other(
+                "restore_session returned AlreadyPresent unexpectedly; session manager might have modified the session store outside of the restore_session API",
+            ));
+        }
+        Ok(RestoreOutcome::NotSupported) => return Ok(false),
+        // Forward-compat: rmcp may add new RestoreOutcome variants. Treat them
+        // as "not supported" so the caller falls through to the normal 404.
+        Ok(_) => return Ok(false),
+        Err(e) => return Err(e),
+    };
+
+    // Step 3: replay the MCP initialize handshake against the new local worker.
+    let service_instance = service.get_service()?;
+
+    // NOTE: upstream rmcp's tower-based restore inserts a `SessionRestoreMarker`
+    // extension so handlers can distinguish a restore replay from a fresh
+    // `initialize`. That struct is `#[non_exhaustive]` with no public
+    // constructor, so we cannot insert it from outside the rmcp crate. Our
+    // `UniversalInboxMcpServer` does not observe the marker, so omitting it is
+    // harmless for our workload.
+    let mut restore_init = ClientJsonRpcMessage::request(
+        ClientRequest::InitializeRequest(InitializeRequest::new(state.initialize_params)),
+        NumberOrString::Number(0),
+    );
+    if let Some(ref hook) = service.on_request {
+        if let ClientJsonRpcMessage::Request(ref mut req_msg) = restore_init {
+            hook(req, req_msg.request.extensions_mut());
+        }
+    }
+
+    let mut restore_initialized = ClientJsonRpcMessage::notification(
+        ClientNotification::InitializedNotification(InitializedNotification::default()),
+    );
+    if let Some(ref hook) = service.on_request {
+        if let ClientJsonRpcMessage::Notification(ref mut not_msg) = restore_initialized {
+            hook(req, not_msg.notification.extensions_mut());
+        }
+    }
+
+    let (init_done_tx, init_done_rx) = tokio::sync::oneshot::channel::<()>();
+
+    spawn_session_worker(
+        service.session_manager.clone(),
+        session_id.clone(),
+        service_instance,
+        transport,
+        Some(init_done_tx),
+    );
+
+    if let Err(e) = service
+        .session_manager
+        .initialize_session(session_id, restore_init)
+        .await
+        .map_err(|e| std::io::Error::other(e.to_string()))
+    {
+        return Err(e);
+    }
+
+    if let Err(e) = service
+        .session_manager
+        .accept_message(session_id, restore_initialized)
+        .await
+        .map_err(|e| std::io::Error::other(e.to_string()))
+    {
+        return Err(e);
+    }
+
+    if init_done_rx.await.is_err() {
+        return Err(std::io::Error::other(
+            "serve_server initialization failed during restore",
+        ));
+    }
+
+    guard.result = true;
+
+    tracing::debug!(
+        session_id = session_id.as_ref(),
+        "session restored from external store"
+    );
+    Ok(true)
+}

--- a/devbox.d/caddy/Caddyfile
+++ b/devbox.d/caddy/Caddyfile
@@ -8,7 +8,19 @@
 
 http://dev.universal-inbox.com {
 	log
-	reverse_proxy :{env.API_PORT}
+
+	handle /api/* {
+		reverse_proxy :{env.API_PORT}
+	}
+
+	@oauth_discovery path /.well-known/oauth-protected-resource /.well-known/oauth-protected-resource/api/mcp /.well-known/oauth-authorization-server
+	handle @oauth_discovery {
+		reverse_proxy :{env.API_PORT}
+	}
+
+	handle {
+		reverse_proxy :{env.DX_SERVE_PORT}
+	}
 }
 
 http://oauth-dev.universal-inbox.com {

--- a/web/.justfile
+++ b/web/.justfile
@@ -51,12 +51,6 @@ test-ci: install build-assets
 run interactive="true": clear-dev-assets build-assets
     #!/usr/bin/env bash
 
-    if [ -n "$API_PORT" ]; then
-        # Update Dioxus.toml proxy to use the correct API port
-        API_URL="http://localhost:${API_PORT:-8000}/api/"
-        sed -i -e "s|backend = \"http://localhost:[0-9]*/api/\"|backend = \"${API_URL}\"|" Dioxus.toml
-    fi
-
     dx serve --port ${DX_SERVE_PORT:-8080} --verbose --interactive false
 
 run-tailwind output-dir="public":


### PR DESCRIPTION
## Summary

Production runs two replicas of the API behind a load balancer. With rmcp's per-process `LocalSessionManager`, a request landing on a different pod than the one that handled `initialize` was rejected with 401, which Claude Code interpreted as token expiry — causing a refresh loop that eventually surfaced as *"the universal-inbox-alan MCP server token has expired and requires re-authorization"*.

This PR bumps `rmcp` to 1.6 and wires its new `SessionStore` trait through a vendored patch of `rmcp-actix-web` 0.12.3 (upstream re-implements its own handlers instead of delegating to rmcp's tower service, so the trait alone is not enough). A new `RedisSessionStore` persists each session's `initialize` parameters; when a follow-up request hits a pod that doesn't know the session, the patched transport loads from Redis and replays the handshake transparently. The missing-session response also flips from 401 to 404 per the MCP spec, so clients re-initialize cleanly instead of looping on token refresh.

## Changes

- **`rmcp` 1.2 → 1.6** in `api/Cargo.toml` to pick up the `SessionStore` trait (`PR modelcontextprotocol/rust-sdk#775`).
- **Vendored patch of `rmcp-actix-web` 0.12.3** under `api/vendor/rmcp-actix-web/`, redirected via `[patch.crates-io]` in the workspace `Cargo.toml`. Patch wires `SessionStore` into `handle_get`/`handle_post`/`handle_delete`: replays the `initialize` handshake on any pod that doesn't know the session, persists state on a fresh `initialize`, deletes on session close, and returns 404 (not 401) for unknown/expired sessions.
- **`RedisSessionStore`** (`api/src/mcp/session_store.rs`) — `SessionStore` impl using the existing `Cache::connection_manager`, JSON-serialized `SessionState`, namespace `universal-inbox:mcp:session:`, configurable TTL via `set_ex`.
- **Wiring** in `api/src/mcp/mod.rs` (`build_http_service` now takes `Arc<dyn SessionStore>`) and `api/src/lib.rs` (constructs `RedisSessionStore` from the existing cache + config).
- **Config** `McpSessionStoreSettings { ttl_seconds }` (always enabled; default 86400s).
- **Unit tests** in `api/tests/api/test_mcp_session_store.rs` covering round-trip, missing-key returns `None`, delete, and TTL.

## Test plan

- [x] `just check` — clippy + compile clean against the patched crate.
- [x] `just test session_store` — 4/4 new unit tests pass.
- [x] `just test test_mcp` — 18/18 existing MCP/OAuth2 tests pass (no regressions on the patched paths).
- [x] Manual two-process smoke test (Caddy round-robining `/api/*` between two API instances sharing the same Postgres + Redis): `initialize` on pod A, `tools/list` with the same `Mcp-Session-Id` lands on pod B, returns 200 — the patched transport restores from Redis.
- [ ] Prod canary on Alan: set `UNIVERSAL_INBOX__APPLICATION__MCP_SESSION_STORE__TTL_SECONDS` (defaulted to 86400) and confirm `qovery log` shows `MCP auth accepted` for every request, `session restored from external store` exactly once per pod-bounce of the same session id, and zero `Unauthorized: Session not found` lines.

## Notes

- The vendored fork is a near-verbatim copy of upstream rmcp 1.6's `tower::try_restore_from_store` adapted for actix-web. The actix version uses the existing `on_request` hook to populate the synthesized `initialize`/`initialized` extensions, since actix middleware already populates the request's extensions (this is how our auth claim reaches the MCP service today).
- `SessionRestoreMarker` is `#[non_exhaustive]` with no public constructor, so it can't be inserted from outside the rmcp crate. Our `UniversalInboxMcpServer` doesn't observe the marker, so omitting it is harmless.
- Out of scope: cross-instance SSE event replay (upstream rust-sdk#330). Universal Inbox tools are pure RPC — request/response only — so we don't need an event store.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/universal-inbox/universal-inbox/pull/163" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Redis-backed MCP session persistence with configurable TTL, enabling sessions to persist across restarts and server instances.
  * Implemented cross-instance session restoration—sessions can now be seamlessly recovered and restored on different pods with automatic handshake replay.
  * Updated session management infrastructure with improved HTTP routing for API and OAuth discovery endpoints.

* **Dependencies**
  * Updated RMCP library to version 1.6 for enhanced session store integration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/universal-inbox/universal-inbox/pull/163)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->